### PR TITLE
[FE] GameLogComponent 생성

### DIFF
--- a/FE/src/App.vue
+++ b/FE/src/App.vue
@@ -16,4 +16,7 @@ body {
   background-size: cover;
   color: #fff;
 }
+li {
+  list-style: none;
+}
 </style>

--- a/FE/src/components/GameLogComponent.vue
+++ b/FE/src/components/GameLogComponent.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <div v-for="info in plate" :key="info.id">
+      <div v-if="info.id === 1" class="current-batter">
+        <span>{{ info.plate }}</span>
+        <span>번 타자 </span>
+        <span>{{ info.batter.name }}</span>
+      </div>
+      <div v-else class="log-batter">
+        <span>{{ info.plate }}</span>
+        <span>번 타자 </span>
+        <span>{{ info.batter.name }}</span>
+      </div>
+
+      <ul v-for="log in info.rounds.slice().reverse()" :key="log.data">
+        <li>
+          <span>{{ log.decision }}</span>
+          <span v-if="log.decision == '안타!'"> </span>
+          <span v-else>
+            <span>S{{ log.strike }}</span>
+            <span>B{{ log.ball }}</span>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+export default {
+  computed: {
+    ...mapState(['plate']),
+  },
+};
+</script>
+
+<style scoped>
+.current-batter {
+  color: red;
+}
+.log-batter {
+  color: rgb(64, 81, 128);
+}
+</style>

--- a/FE/src/store/index.js
+++ b/FE/src/store/index.js
@@ -6,6 +6,11 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     matchArr: {
+      inningMeaage: '2회초 공격',
+      inning: {
+        firstHalf: 2,
+        secondHalf: 2,
+      },
       homeTeam: {
         name: 'testA',
         score: 0,
@@ -81,8 +86,135 @@ export default new Vuex.Store({
         ],
       },
     },
+    plate: [
+      {
+        id: 1,
+        plate: 7,
+        batter: {
+          name: '김광진',
+          mount: 1,
+          hit: 0,
+          pitcher: false,
+        },
+        rounds: [
+          {
+            decision: '스트라이크',
+            strike: 1,
+            ball: 0,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 1,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 2,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 3,
+          },
+          {
+            decision: '스트라이크',
+            strike: 2,
+            ball: 3,
+          },
+          {
+            decision: '안타!',
+            strike: 0,
+            ball: 0,
+          },
+        ],
+      },
+      {
+        id: 2,
+        plate: 7,
+        batter: {
+          name: '김광진',
+          mount: 1,
+          hit: 0,
+          pitcher: false,
+        },
+        rounds: [
+          {
+            decision: '스트라이크',
+            strike: 1,
+            ball: 0,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 1,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 2,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 3,
+          },
+          {
+            decision: '스트라이크',
+            strike: 2,
+            ball: 3,
+          },
+          {
+            decision: '안타!',
+            strike: 0,
+            ball: 0,
+          },
+        ],
+      },
+      {
+        id: 3,
+        plate: 7,
+        batter: {
+          name: '김광진',
+          mount: 1,
+          hit: 0,
+          pitcher: false,
+        },
+        rounds: [
+          {
+            decision: '스트라이크',
+            strike: 1,
+            ball: 0,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 1,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 2,
+          },
+          {
+            decision: '볼',
+            strike: 1,
+            ball: 3,
+          },
+          {
+            decision: '스트라이크',
+            strike: 2,
+            ball: 3,
+          },
+          {
+            decision: '안타!',
+            strike: 0,
+            ball: 0,
+          },
+        ],
+      },
+    ],
   },
-  getters: {},
   mutations: {},
   actions: {},
 });

--- a/FE/src/views/GameView.vue
+++ b/FE/src/views/GameView.vue
@@ -2,17 +2,23 @@
   <div>
     <main-score-component></main-score-component>
     <player-component></player-component>
+    <game-board></game-board>
+    <game-log-component></game-log-component>
   </div>
 </template>
 
 <script>
 import MainScoreComponent from '@/components/MainScoreComponent';
 import PlayerComponent from '@/components/PlayerComponent';
+import GameBoard from '@/components/GameBoardComponent';
+import GameLogComponent from '@/components/GameLogComponent';
 
 export default {
   components: {
     MainScoreComponent,
     PlayerComponent,
+    GameBoard,
+    GameLogComponent,
   },
 };
 </script>


### PR DESCRIPTION
#### 경기 진행상황이 기록된다

<img width="156" alt="스크린샷 2020-05-07 오후 1 50 49" src="https://user-images.githubusercontent.com/48382080/81255859-c4721c80-9069-11ea-9cf5-f1c19a9771fa.png">

- [x] 중계 영역은 투수가 공을 던질 때마다 업데이트된다.
- 현재 타자 이름은 현재 타자가 공을 치는 동안 강조된 색깔로 상단에 고정된다.
- 투수가 새로 공을 던질 때마다 고정된 타자 이름 아래 내용들이 밀리면서 새로운 공과 볼카운트가 나타난다.
- 다음 타자로 교체되면 지난 타자의 이름의 색깔이 변경되고 다른 내용들과 마찬가지로 함께 아래로 밀린다.
- 중계 영역은 내용이 쌓이면 스크롤 되며 지나간 내용을 볼 수 있다.
