### PR TITLE
[FE] 경기 목록 API 연동 작업

### DIFF
--- a/FE/.env
+++ b/FE/.env
@@ -1,0 +1,1 @@
+VUE_APP_BASE_MOCKDATA=http://15.165.69.44:8080/mock/

--- a/FE/.env.development
+++ b/FE/.env.development
@@ -1,0 +1,1 @@
+VUE_APP_BASE_MOCKDATA=http://15.165.69.44:8080/mock/

--- a/FE/src/api/common/interceptors.js
+++ b/FE/src/api/common/interceptors.js
@@ -1,0 +1,23 @@
+import store from '@/store/index';
+
+export function setInterceptors(instance) {
+  instance.interceptors.request.use(
+    function (config) {
+      config.headers.Authorization = store.state.token;
+      return config;
+    },
+    function (error) {
+      return Promise.reject(error);
+    },
+  );
+
+  instance.interceptors.response.use(
+    function (response) {
+      return response;
+    },
+    function (error) {
+      return Promise.reject(error);
+    },
+  );
+  return instance;
+}

--- a/FE/src/api/game.js
+++ b/FE/src/api/game.js
@@ -1,0 +1,7 @@
+import { instance } from './index';
+
+function fetchMatches() {
+  return instance.get('matches');
+}
+
+export { fetchMatches };

--- a/FE/src/api/index.js
+++ b/FE/src/api/index.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+function createInstance() {
+  return axios.create({
+    baseURL: process.env.VUE_APP_BASE_MOCKDATA,
+  });
+}
+
+export const instance = createInstance();

--- a/FE/src/components/TeamComponent.vue
+++ b/FE/src/components/TeamComponent.vue
@@ -3,49 +3,59 @@
     <div class="title-container">
       <h2>BASEBALL GAME ONLINE</h2>
     </div>
-    <div class="team-container">
-      <div v-for="team in matchArr" :key="team.id" class="match-container">
-        <span class="" @click="onClickSelectTeam">{{ team.home }}</span> vs
-        <span @click="onClickSelectTeam">{{ team.away }}</span>
+    <h2>참가할 게임을 선택하세요!</h2>
+    <div class="list-container">
+      <div
+        class="team-container"
+        v-for="(team, index) in matchList"
+        :key="team.id"
+      >
+        <button class="match-container" :class="{ active: team.selectable }">
+          <div class="game-number">GAME{{ index + 1 }}</div>
+          <span class="home-team team" @click="onClickSelectTeam">{{
+            team.homeTeam
+          }}</span>
+          vs
+          <span class="away-team team" @click="onClickSelectTeam">{{
+            team.awayTeam
+          }}</span>
+        </button>
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import axios from 'axios';
+import { mapState } from 'vuex';
+import { fetchMatches } from '@/api/game';
+
 export default {
   data() {
     return {
-      matchArr: [
-        {
-          id: 1,
-          home: '삼성',
-          away: '두산',
-        },
-        {
-          id: 2,
-          home: '한화',
-          away: '넥센',
-        },
-        {
-          id: 3,
-          home: '롯데',
-          away: '기아',
-        },
-        {
-          id: 4,
-          home: 'NC',
-          away: 'SK',
-        },
-      ],
+      matchList: [],
     };
   },
+
+  computed: {
+    ...mapState(['matchesList']),
+  },
+
+  created() {
+    this.fetchData();
+  },
+
   methods: {
+    async fetchData() {
+      const { data } = await fetchMatches();
+      console.log(data);
+      this.matchList = data;
+    },
+
     onClickSelectTeam: function ({ target: { innerText } }) {
-      const matchObj = this.matchArr.find(
+      const matchObj = this.matchList.find(
         el => el.home == innerText || el.away == innerText,
       );
-      // console.log(matchObj);
       this.$router.push(`main/${innerText}`);
     },
   },
@@ -55,8 +65,11 @@ export default {
 <style scoped>
 .warp {
   padding: 10px;
-  background-color: #000;
-  opacity: 50%;
+  background-color: #00000080;
+}
+
+.game-number {
+  font-size: 15px;
 }
 
 .title-container > h2 {
@@ -65,7 +78,43 @@ export default {
 }
 
 .match-container {
+  background-color: #ffffff80;
+  margin: 15px auto;
+  display: block;
+  width: 400px;
   padding: 10px;
   font-size: 24px;
+}
+
+.list-container {
+  overflow: auto;
+  height: 220px;
+}
+
+.list-container::-webkit-scrollbar {
+  display: none;
+}
+
+.active {
+  background-color: #ff0000;
+  color: #fff;
+  pointer-events: none;
+  position: relative;
+}
+
+.active::after {
+  position: absolute;
+  left: 15px;
+  font-size: 15px;
+  content: '게임중';
+  color: #fff;
+}
+
+.team {
+  margin: 0 10px;
+}
+
+.team:hover {
+  color: red;
 }
 </style>

--- a/FE/src/store/index.js
+++ b/FE/src/store/index.js
@@ -5,6 +5,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
+    matchesList: [],
     matchArr: {
       inningMeaage: '2회초 공격',
       inning: {


### PR DESCRIPTION
#### 경기 목록 API 통신

 - [x] API에서 경기 목록을 받아와서 랜더링 작업을 한다
 - [x] 스타일 작업도 같이 진행한다
 - [x] 팀을 선택할때 마우스를 호버하면 강조되는 스타일링을 작업한다
 - [x] 경기 목록에서 home,away중 한팀을 선택하면 그경기는 다시 선택을 못하게 비활성화 시킨다
 - [x] 비활성화된 경기를 클릭하면 이미 선택된 팀이라는 메시지를 보내준다
 - [x] 경기가 많이질경우 스크롤 되는 작업을 한다