### PR TITLE
[iOS][#35] 게임 진행 화면과 게임 스코어 화면의 공통된 뷰들을 만들었습니다.

### DIFF
--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		5A814F6A246664DE001C768D /* PlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F69246664DE001C768D /* PlayViewController.swift */; };
 		5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6B24666502001C768D /* ScoresViewController.swift */; };
 		5A814F6E24669226001C768D /* IdentifiableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6D24669226001C768D /* IdentifiableViewController.swift */; };
+		5A814F702466AC9A001C768D /* ScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6F2466AC9A001C768D /* ScoreView.swift */; };
+		5A814F722466ACB0001C768D /* ScoreView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F712466ACB0001C768D /* ScoreView.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +115,8 @@
 		5A814F69246664DE001C768D /* PlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayViewController.swift; sourceTree = "<group>"; };
 		5A814F6B24666502001C768D /* ScoresViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoresViewController.swift; sourceTree = "<group>"; };
 		5A814F6D24669226001C768D /* IdentifiableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableViewController.swift; sourceTree = "<group>"; };
+		5A814F6F2466AC9A001C768D /* ScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreView.swift; sourceTree = "<group>"; };
+		5A814F712466ACB0001C768D /* ScoreView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ScoreView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -316,6 +320,8 @@
 			children = (
 				5A814F6324658E25001C768D /* TitleView.xib */,
 				5A814F6724665B23001C768D /* TitleView.swift */,
+				5A814F6F2466AC9A001C768D /* ScoreView.swift */,
+				5A814F712466ACB0001C768D /* ScoreView.xib */,
 			);
 			path = Game;
 			sourceTree = "<group>";
@@ -425,6 +431,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5A7DD5162460170A002ECB3A /* LaunchScreen.storyboard in Resources */,
+				5A814F722466ACB0001C768D /* ScoreView.xib in Resources */,
 				5A7DD5132460170A002ECB3A /* Assets.xcassets in Resources */,
 				5A814F6424658E25001C768D /* TitleView.xib in Resources */,
 				5A814EE924627B5B001C768D /* TeamInfoSuccessStub.json in Resources */,
@@ -459,6 +466,7 @@
 				5A7DD54A24604DE9002ECB3A /* GameRoomCollectionView.swift in Sources */,
 				5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */,
 				5A814EF824629BF7001C768D /* NetworkDispatcher.swift in Sources */,
+				5A814F702466AC9A001C768D /* ScoreView.swift in Sources */,
 				5A814F6824665B23001C768D /* TitleView.swift in Sources */,
 				5A814F0A2462AD99001C768D /* MockGameRoomSuccess.swift in Sources */,
 				5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		5A814F6024645F07001C768D /* PrevButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5F24645F07001C768D /* PrevButton.swift */; };
 		5A814F6424658E25001C768D /* TitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F6324658E25001C768D /* TitleView.xib */; };
 		5A814F6824665B23001C768D /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6724665B23001C768D /* TitleView.swift */; };
+		5A814F6A246664DE001C768D /* PlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F69246664DE001C768D /* PlayViewController.swift */; };
+		5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6B24666502001C768D /* ScoresViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,6 +109,8 @@
 		5A814F5F24645F07001C768D /* PrevButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrevButton.swift; sourceTree = "<group>"; };
 		5A814F6324658E25001C768D /* TitleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleView.xib; sourceTree = "<group>"; };
 		5A814F6724665B23001C768D /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
+		5A814F69246664DE001C768D /* PlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayViewController.swift; sourceTree = "<group>"; };
+		5A814F6B24666502001C768D /* ScoresViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoresViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -290,6 +294,8 @@
 				5A814F5D246451B2001C768D /* MainViewController.swift */,
 				5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */,
 				5A814F5B24645052001C768D /* LoginViewController.swift */,
+				5A814F69246664DE001C768D /* PlayViewController.swift */,
+				5A814F6B24666502001C768D /* ScoresViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -448,6 +454,7 @@
 				5A7DD54624603A0E002ECB3A /* VersusLabel.swift in Sources */,
 				5A814EED24627BD5001C768D /* DataExtensions.swift in Sources */,
 				5A7DD54A24604DE9002ECB3A /* GameRoomCollectionView.swift in Sources */,
+				5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */,
 				5A814EF824629BF7001C768D /* NetworkDispatcher.swift in Sources */,
 				5A814F6824665B23001C768D /* TitleView.swift in Sources */,
 				5A814F0A2462AD99001C768D /* MockGameRoomSuccess.swift in Sources */,
@@ -456,6 +463,7 @@
 				5A814EE724625703001C768D /* VersusViewModel.swift in Sources */,
 				5A814EFA2462A0D9001C768D /* NetworkTask.swift in Sources */,
 				5A7DD540246035F7002ECB3A /* GameRoomCell.swift in Sources */,
+				5A814F6A246664DE001C768D /* PlayViewController.swift in Sources */,
 				5A814F532464016D001C768D /* ReusableView.swift in Sources */,
 				5A814F5C24645052001C768D /* LoginViewController.swift in Sources */,
 				5A7DD54C246056AD002ECB3A /* GameRoomViewModels.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		5A814F6824665B23001C768D /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6724665B23001C768D /* TitleView.swift */; };
 		5A814F6A246664DE001C768D /* PlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F69246664DE001C768D /* PlayViewController.swift */; };
 		5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6B24666502001C768D /* ScoresViewController.swift */; };
+		5A814F6E24669226001C768D /* IdentifiableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6D24669226001C768D /* IdentifiableViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		5A814F6724665B23001C768D /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		5A814F69246664DE001C768D /* PlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayViewController.swift; sourceTree = "<group>"; };
 		5A814F6B24666502001C768D /* ScoresViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoresViewController.swift; sourceTree = "<group>"; };
+		5A814F6D24669226001C768D /* IdentifiableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -291,6 +293,7 @@
 		5A814F512463F93F001C768D /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				5A814F6D24669226001C768D /* IdentifiableViewController.swift */,
 				5A814F5D246451B2001C768D /* MainViewController.swift */,
 				5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */,
 				5A814F5B24645052001C768D /* LoginViewController.swift */,
@@ -476,6 +479,7 @@
 				5A814F6024645F07001C768D /* PrevButton.swift in Sources */,
 				5A814F5A24644B15001C768D /* OauthLoginButton.swift in Sources */,
 				5A814EF62462810B001C768D /* Request.swift in Sources */,
+				5A814F6E24669226001C768D /* IdentifiableViewController.swift in Sources */,
 				5A814F5824643A9D001C768D /* UIColorExtension.swift in Sources */,
 				5A814F032462AB84001C768D /* GameRoomUseCase.swift in Sources */,
 				5A814F122462DEDF001C768D /* ViewModelBinding.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		5A814F5C24645052001C768D /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5B24645052001C768D /* LoginViewController.swift */; };
 		5A814F5E246451B2001C768D /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5D246451B2001C768D /* MainViewController.swift */; };
 		5A814F6024645F07001C768D /* PrevButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5F24645F07001C768D /* PrevButton.swift */; };
+		5A814F6424658E25001C768D /* TitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F6324658E25001C768D /* TitleView.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,6 +104,7 @@
 		5A814F5B24645052001C768D /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		5A814F5D246451B2001C768D /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		5A814F5F24645F07001C768D /* PrevButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrevButton.swift; sourceTree = "<group>"; };
+		5A814F6324658E25001C768D /* TitleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -194,6 +196,7 @@
 		5A7DD53C24602B83002ECB3A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5A814F6624665A07001C768D /* Game */,
 				5A814F132462EB9F001C768D /* GameRoom */,
 				5A7DD53D24602B9F002ECB3A /* TitleLabel.swift */,
 				5A7DD54524603A0E002ECB3A /* VersusLabel.swift */,
@@ -295,6 +298,14 @@
 				5A814F5724643A9D001C768D /* UIColorExtension.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		5A814F6624665A07001C768D /* Game */ = {
+			isa = PBXGroup;
+			children = (
+				5A814F6324658E25001C768D /* TitleView.xib */,
+			);
+			path = Game;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -403,6 +414,7 @@
 			files = (
 				5A7DD5162460170A002ECB3A /* LaunchScreen.storyboard in Resources */,
 				5A7DD5132460170A002ECB3A /* Assets.xcassets in Resources */,
+				5A814F6424658E25001C768D /* TitleView.xib in Resources */,
 				5A814EE924627B5B001C768D /* TeamInfoSuccessStub.json in Resources */,
 				5A7DD51124601708002ECB3A /* Main.storyboard in Resources */,
 			);

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		5A814F0A2462AD99001C768D /* MockGameRoomSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F092462AD99001C768D /* MockGameRoomSuccess.swift */; };
 		5A814F102462DED2001C768D /* GameRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F0F2462DED2001C768D /* GameRoomViewModel.swift */; };
 		5A814F122462DEDF001C768D /* ViewModelBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F112462DEDF001C768D /* ViewModelBinding.swift */; };
-		5A814F532464016D001C768D /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F522464016D001C768D /* ReusableView.swift */; };
+		5A814F532464016D001C768D /* IdentifiableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F522464016D001C768D /* IdentifiableView.swift */; };
 		5A814F55246439B2001C768D /* BorderedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F54246439B2001C768D /* BorderedButton.swift */; };
 		5A814F5824643A9D001C768D /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5724643A9D001C768D /* UIColorExtension.swift */; };
 		5A814F5A24644B15001C768D /* OauthLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5924644B15001C768D /* OauthLoginButton.swift */; };
@@ -100,7 +100,7 @@
 		5A814F092462AD99001C768D /* MockGameRoomSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGameRoomSuccess.swift; sourceTree = "<group>"; };
 		5A814F0F2462DED2001C768D /* GameRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameRoomViewModel.swift; sourceTree = "<group>"; };
 		5A814F112462DEDF001C768D /* ViewModelBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBinding.swift; sourceTree = "<group>"; };
-		5A814F522464016D001C768D /* ReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
+		5A814F522464016D001C768D /* IdentifiableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableView.swift; sourceTree = "<group>"; };
 		5A814F54246439B2001C768D /* BorderedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedButton.swift; sourceTree = "<group>"; };
 		5A814F5724643A9D001C768D /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		5A814F5924644B15001C768D /* OauthLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OauthLoginButton.swift; sourceTree = "<group>"; };
@@ -206,7 +206,7 @@
 				5A814F132462EB9F001C768D /* GameRoom */,
 				5A7DD53D24602B9F002ECB3A /* TitleLabel.swift */,
 				5A7DD54524603A0E002ECB3A /* VersusLabel.swift */,
-				5A814F522464016D001C768D /* ReusableView.swift */,
+				5A814F522464016D001C768D /* IdentifiableView.swift */,
 				5A814F54246439B2001C768D /* BorderedButton.swift */,
 				5A814F5924644B15001C768D /* OauthLoginButton.swift */,
 			);
@@ -464,7 +464,7 @@
 				5A814EFA2462A0D9001C768D /* NetworkTask.swift in Sources */,
 				5A7DD540246035F7002ECB3A /* GameRoomCell.swift in Sources */,
 				5A814F6A246664DE001C768D /* PlayViewController.swift in Sources */,
-				5A814F532464016D001C768D /* ReusableView.swift in Sources */,
+				5A814F532464016D001C768D /* IdentifiableView.swift in Sources */,
 				5A814F5C24645052001C768D /* LoginViewController.swift in Sources */,
 				5A7DD54C246056AD002ECB3A /* GameRoomViewModels.swift in Sources */,
 				5A814F5E246451B2001C768D /* MainViewController.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		5A814F5E246451B2001C768D /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5D246451B2001C768D /* MainViewController.swift */; };
 		5A814F6024645F07001C768D /* PrevButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F5F24645F07001C768D /* PrevButton.swift */; };
 		5A814F6424658E25001C768D /* TitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F6324658E25001C768D /* TitleView.xib */; };
+		5A814F6824665B23001C768D /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6724665B23001C768D /* TitleView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +106,7 @@
 		5A814F5D246451B2001C768D /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		5A814F5F24645F07001C768D /* PrevButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrevButton.swift; sourceTree = "<group>"; };
 		5A814F6324658E25001C768D /* TitleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleView.xib; sourceTree = "<group>"; };
+		5A814F6724665B23001C768D /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -304,6 +306,7 @@
 			isa = PBXGroup;
 			children = (
 				5A814F6324658E25001C768D /* TitleView.xib */,
+				5A814F6724665B23001C768D /* TitleView.swift */,
 			);
 			path = Game;
 			sourceTree = "<group>";
@@ -446,6 +449,7 @@
 				5A814EED24627BD5001C768D /* DataExtensions.swift in Sources */,
 				5A7DD54A24604DE9002ECB3A /* GameRoomCollectionView.swift in Sources */,
 				5A814EF824629BF7001C768D /* NetworkDispatcher.swift in Sources */,
+				5A814F6824665B23001C768D /* TitleView.swift in Sources */,
 				5A814F0A2462AD99001C768D /* MockGameRoomSuccess.swift in Sources */,
 				5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */,
 				5A7DD53E24602B9F002ECB3A /* TitleLabel.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -198,7 +198,7 @@
         <!--Scores-->
         <scene sceneID="oEH-SC-OQW">
             <objects>
-                <viewController id="qaG-7m-vvT" sceneMemberID="viewController">
+                <viewController id="qaG-7m-vvT" customClass="ScoresViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aJF-G8-Naq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -214,7 +214,7 @@
         <!--Play-->
         <scene sceneID="OBo-LC-OwZ">
             <objects>
-                <viewController id="cSG-l2-sFt" sceneMemberID="viewController">
+                <viewController id="cSG-l2-sFt" customClass="PlayViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kMd-Vk-jkA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -20,7 +20,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mxX-eE-OXR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="7" y="23"/>
+            <point key="canvasLocation" x="7" y="59"/>
         </scene>
         <!--Main View Controller-->
         <scene sceneID="vCQ-bo-Oet">
@@ -193,7 +193,39 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Nxq-AB-Y0D" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1804" y="-647.22638680659679"/>
+            <point key="canvasLocation" x="1884" y="-649"/>
+        </scene>
+        <!--Scores-->
+        <scene sceneID="oEH-SC-OQW">
+            <objects>
+                <viewController id="qaG-7m-vvT" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aJF-G8-Naq">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Xg0-XO-y3c"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Scores" image="chart.bar" catalog="system" id="KJ9-3a-nZn"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BAh-Be-o6g" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1884" y="-1352.473763118441"/>
+        </scene>
+        <!--Play-->
+        <scene sceneID="OBo-LC-OwZ">
+            <objects>
+                <viewController id="cSG-l2-sFt" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="kMd-Vk-jkA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Play" image="gamecontroller" catalog="system" id="qTj-Jz-o3m"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Aro-p9-AII" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="944.79999999999995" y="-1352.473763118441"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="sjk-mX-yFT">
@@ -212,9 +244,30 @@
             </objects>
             <point key="canvasLocation" x="7.2000000000000002" y="-649.02548725637189"/>
         </scene>
+        <!--Tab Bar Controller-->
+        <scene sceneID="kTD-IT-ySK">
+            <objects>
+                <tabBarController storyboardIdentifier="GameTabBarController" automaticallyAdjustsScrollViewInsets="NO" id="Q1g-jb-zgg" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="E5Q-AV-pq1">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="cSG-l2-sFt" kind="relationship" relationship="viewControllers" id="ip2-aq-OjZ"/>
+                        <segue destination="qaG-7m-vvT" kind="relationship" relationship="viewControllers" id="S3a-dq-1kQ"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5f7-ha-pru" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5.5999999999999996" y="-1352.473763118441"/>
+        </scene>
     </scenes>
     <resources>
         <image name="batter" width="400" height="400"/>
+        <image name="chart.bar" catalog="system" width="128" height="90"/>
+        <image name="gamecontroller" catalog="system" width="128" height="82"/>
         <image name="github" width="21.333333969116211" height="21.333333969116211"/>
     </resources>
 </document>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -234,12 +234,13 @@
                             <state key="normal" image="xmark" catalog="system"/>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qgO-Od-bLq">
-                            <rect key="frame" x="111" y="7" width="153" height="21"/>
+                            <rect key="frame" x="106.5" y="7" width="162.5" height="21"/>
                             <attributedString key="attributedText">
-                                <fragment content="kbo baseball game">
+                                <fragment content="KBO Baseball game">
                                     <attributes>
                                         <color key="NSColor" red="0.050980392156862744" green="0.16078431372549018" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <font key="NSFont" size="17" name="HelveticaNeue-BoldItalic"/>
+                                        <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                     </attributes>
                                 </fragment>
                             </attributedString>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -212,7 +212,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstItem="mBQ-yj-4gl" firstAttribute="width" secondItem="Xg0-XO-y3c" secondAttribute="width" id="8GT-Vo-oeS"/>
                             <constraint firstItem="mBQ-yj-4gl" firstAttribute="top" secondItem="Xg0-XO-y3c" secondAttribute="top" id="kHB-AS-E0E"/>
@@ -241,7 +241,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="top" secondItem="Hvq-eV-AVL" secondAttribute="top" id="0mA-Nc-q4r"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Bc8-Eg-gBM"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -198,7 +198,6 @@
         <!--Scores-->
         <scene sceneID="oEH-SC-OQW">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BAh-Be-o6g" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <viewController id="qaG-7m-vvT" customClass="ScoresViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aJF-G8-Naq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
@@ -210,12 +209,22 @@
                                     <constraint firstAttribute="width" secondItem="mBQ-yj-4gl" secondAttribute="height" multiplier="17:1" id="lJz-Oj-Lis"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hYS-x3-cZA" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="22" width="375" height="41.5"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="hYS-x3-cZA" secondAttribute="height" multiplier="9:1" id="yLB-Fz-PLB"/>
+                                </constraints>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="hYS-x3-cZA" firstAttribute="top" secondItem="mBQ-yj-4gl" secondAttribute="bottom" id="5e3-oS-xaH"/>
                             <constraint firstItem="mBQ-yj-4gl" firstAttribute="width" secondItem="Xg0-XO-y3c" secondAttribute="width" id="8GT-Vo-oeS"/>
+                            <constraint firstItem="hYS-x3-cZA" firstAttribute="leading" secondItem="Xg0-XO-y3c" secondAttribute="leading" id="fdP-K6-smS"/>
                             <constraint firstItem="mBQ-yj-4gl" firstAttribute="top" secondItem="Xg0-XO-y3c" secondAttribute="top" id="kHB-AS-E0E"/>
                             <constraint firstItem="Xg0-XO-y3c" firstAttribute="leading" secondItem="mBQ-yj-4gl" secondAttribute="leading" id="qq4-Zg-gog"/>
+                            <constraint firstItem="hYS-x3-cZA" firstAttribute="width" secondItem="Xg0-XO-y3c" secondAttribute="width" id="yNg-4C-5nu"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Xg0-XO-y3c"/>
                     </view>
@@ -224,6 +233,7 @@
                         <outlet property="titleView" destination="mBQ-yj-4gl" id="tYH-x8-1ya"/>
                     </connections>
                 </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BAh-Be-o6g" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1884" y="-1352.473763118441"/>
         </scene>
@@ -241,12 +251,21 @@
                                     <constraint firstAttribute="width" secondItem="aSi-rk-FUG" secondAttribute="height" multiplier="17:1" id="yiO-X5-Xao"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jpd-qi-a5W" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="22" width="375" height="41.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="jpd-qi-a5W" secondAttribute="height" multiplier="9:1" id="GjB-B1-QwW"/>
+                                </constraints>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="top" secondItem="Hvq-eV-AVL" secondAttribute="top" id="0mA-Nc-q4r"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Bc8-Eg-gBM"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="Tre-pF-HCn"/>
+                            <constraint firstItem="jpd-qi-a5W" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Wwo-Lt-iZX"/>
+                            <constraint firstItem="jpd-qi-a5W" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dDA-x6-gdQ"/>
+                            <constraint firstItem="jpd-qi-a5W" firstAttribute="top" secondItem="aSi-rk-FUG" secondAttribute="bottom" id="n8k-hw-9jE"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>
                     </view>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -224,6 +224,37 @@
                     <tabBarItem key="tabBarItem" title="Play" image="gamecontroller" catalog="system" id="qTj-Jz-o3m"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Aro-p9-AII" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <view contentMode="scaleToFill" id="U2k-O9-C9j" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="35"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lka-F1-jRM">
+                            <rect key="frame" x="15" y="6.5" width="18" height="22"/>
+                            <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <state key="normal" image="xmark" catalog="system"/>
+                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qgO-Od-bLq">
+                            <rect key="frame" x="111" y="7" width="153" height="21"/>
+                            <attributedString key="attributedText">
+                                <fragment content="kbo baseball game">
+                                    <attributes>
+                                        <color key="NSColor" red="0.050980392156862744" green="0.16078431372549018" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <font key="NSFont" size="17" name="HelveticaNeue-BoldItalic"/>
+                                    </attributes>
+                                </fragment>
+                            </attributedString>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstItem="qgO-Od-bLq" firstAttribute="centerX" secondItem="RN2-RS-fHf" secondAttribute="centerX" id="0pL-xR-bS9"/>
+                        <constraint firstItem="qgO-Od-bLq" firstAttribute="centerY" secondItem="RN2-RS-fHf" secondAttribute="centerY" id="3Y1-rg-g5N"/>
+                        <constraint firstItem="lka-F1-jRM" firstAttribute="centerY" secondItem="RN2-RS-fHf" secondAttribute="centerY" id="WbT-g7-hYi"/>
+                        <constraint firstItem="lka-F1-jRM" firstAttribute="leading" secondItem="RN2-RS-fHf" secondAttribute="leading" constant="15" id="lRz-qI-Cbf"/>
+                    </constraints>
+                    <viewLayoutGuide key="safeArea" id="RN2-RS-fHf"/>
+                </view>
             </objects>
             <point key="canvasLocation" x="944.79999999999995" y="-1352.473763118441"/>
         </scene>
@@ -269,5 +300,6 @@
         <image name="chart.bar" catalog="system" width="128" height="90"/>
         <image name="gamecontroller" catalog="system" width="128" height="82"/>
         <image name="github" width="21.333333969116211" height="21.333333969116211"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
     </resources>
 </document>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -198,16 +198,30 @@
         <!--Scores-->
         <scene sceneID="oEH-SC-OQW">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BAh-Be-o6g" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <viewController id="qaG-7m-vvT" customClass="ScoresViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aJF-G8-Naq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mBQ-yj-4gl" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="mBQ-yj-4gl" secondAttribute="height" multiplier="17:1" id="lJz-Oj-Lis"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="mBQ-yj-4gl" firstAttribute="width" secondItem="Xg0-XO-y3c" secondAttribute="width" id="8GT-Vo-oeS"/>
+                            <constraint firstItem="mBQ-yj-4gl" firstAttribute="top" secondItem="Xg0-XO-y3c" secondAttribute="top" id="kHB-AS-E0E"/>
+                            <constraint firstItem="Xg0-XO-y3c" firstAttribute="leading" secondItem="mBQ-yj-4gl" secondAttribute="leading" id="qq4-Zg-gog"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Xg0-XO-y3c"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Scores" image="chart.bar" catalog="system" id="KJ9-3a-nZn"/>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BAh-Be-o6g" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1884" y="-1352.473763118441"/>
         </scene>
@@ -218,44 +232,26 @@
                     <view key="view" contentMode="scaleToFill" id="kMd-Vk-jkA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aSi-rk-FUG" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="aSi-rk-FUG" secondAttribute="height" multiplier="17:1" id="yiO-X5-Xao"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="aSi-rk-FUG" firstAttribute="top" secondItem="Hvq-eV-AVL" secondAttribute="top" id="0mA-Nc-q4r"/>
+                            <constraint firstItem="aSi-rk-FUG" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Bc8-Eg-gBM"/>
+                            <constraint firstItem="aSi-rk-FUG" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="Tre-pF-HCn"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Play" image="gamecontroller" catalog="system" id="qTj-Jz-o3m"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Aro-p9-AII" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <view contentMode="scaleToFill" id="U2k-O9-C9j" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="35"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lka-F1-jRM">
-                            <rect key="frame" x="15" y="6.5" width="18" height="22"/>
-                            <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <state key="normal" image="xmark" catalog="system"/>
-                        </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qgO-Od-bLq">
-                            <rect key="frame" x="106.5" y="7" width="162.5" height="21"/>
-                            <attributedString key="attributedText">
-                                <fragment content="KBO Baseball game">
-                                    <attributes>
-                                        <color key="NSColor" red="0.050980392156862744" green="0.16078431372549018" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <font key="NSFont" size="17" name="HelveticaNeue-BoldItalic"/>
-                                        <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                    </attributes>
-                                </fragment>
-                            </attributedString>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    <constraints>
-                        <constraint firstItem="qgO-Od-bLq" firstAttribute="centerX" secondItem="RN2-RS-fHf" secondAttribute="centerX" id="0pL-xR-bS9"/>
-                        <constraint firstItem="qgO-Od-bLq" firstAttribute="centerY" secondItem="RN2-RS-fHf" secondAttribute="centerY" id="3Y1-rg-g5N"/>
-                        <constraint firstItem="lka-F1-jRM" firstAttribute="centerY" secondItem="RN2-RS-fHf" secondAttribute="centerY" id="WbT-g7-hYi"/>
-                        <constraint firstItem="lka-F1-jRM" firstAttribute="leading" secondItem="RN2-RS-fHf" secondAttribute="leading" constant="15" id="lRz-qI-Cbf"/>
-                    </constraints>
-                    <viewLayoutGuide key="safeArea" id="RN2-RS-fHf"/>
-                </view>
             </objects>
             <point key="canvasLocation" x="944.79999999999995" y="-1352.473763118441"/>
         </scene>
@@ -301,6 +297,5 @@
         <image name="chart.bar" catalog="system" width="128" height="90"/>
         <image name="gamecontroller" catalog="system" width="128" height="82"/>
         <image name="github" width="21.333333969116211" height="21.333333969116211"/>
-        <image name="xmark" catalog="system" width="128" height="113"/>
     </resources>
 </document>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -206,7 +206,6 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mBQ-yj-4gl" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="mBQ-yj-4gl" secondAttribute="height" multiplier="17:1" id="lJz-Oj-Lis"/>
                                 </constraints>
@@ -235,7 +234,6 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aSi-rk-FUG" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="aSi-rk-FUG" secondAttribute="height" multiplier="17:1" id="yiO-X5-Xao"/>
                                 </constraints>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -220,6 +220,9 @@
                         <viewLayoutGuide key="safeArea" id="Xg0-XO-y3c"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Scores" image="chart.bar" catalog="system" id="KJ9-3a-nZn"/>
+                    <connections>
+                        <outlet property="titleView" destination="mBQ-yj-4gl" id="tYH-x8-1ya"/>
+                    </connections>
                 </viewController>
             </objects>
             <point key="canvasLocation" x="1884" y="-1352.473763118441"/>
@@ -248,6 +251,9 @@
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Play" image="gamecontroller" catalog="system" id="qTj-Jz-o3m"/>
+                    <connections>
+                        <outlet property="titleView" destination="aSi-rk-FUG" id="Ym4-Us-3jZ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Aro-p9-AII" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
@@ -55,7 +55,7 @@ final class GameRoomViewController: UIViewController {
     private func configureCollectionView() {
         gameRoomCollectionView = GameRoomCollectionView(collectionViewLayout:
             GameRoomCollectionViewFlowLayout(superFrame: view.frame))
-        gameRoomCollectionView.register(GameRoomCell.self, forCellWithReuseIdentifier: GameRoomCell.reuseIdentifier)
+        gameRoomCollectionView.register(GameRoomCell.self, forCellWithReuseIdentifier: GameRoomCell.identifier)
         gameRoomCollectionView.dataSource = self
         gameRoomCollectionView.delegate = self
         configureCollectionViewConstraints()
@@ -101,7 +101,7 @@ extension GameRoomViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let gameRoomCell = collectionView.dequeueReusableCell(withReuseIdentifier: GameRoomCell.reuseIdentifier,
+        guard let gameRoomCell = collectionView.dequeueReusableCell(withReuseIdentifier: GameRoomCell.identifier,
                                                                     for: indexPath) as? GameRoomCell
             else { return GameRoomCell() }
         

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class GameRoomViewController: UIViewController {
+final class GameRoomViewController: UIViewController, IdentifiableViewController {
     //MARK:- Internal properties
     private let gameRoomTitleLabel: TitleLabel = {
         let label = TitleLabel()

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
@@ -120,7 +120,6 @@ extension GameRoomViewController: UICollectionViewDelegate {
     private func showGameTabBarController() {
         guard let gameTabBarController = storyboard?.instantiateViewController(withIdentifier: "GameTabBarController")
             else { return }
-        gameTabBarController.modalTransitionStyle = .crossDissolve
         gameTabBarController.modalPresentationStyle = .fullScreen
         present(gameTabBarController, animated: true)
     }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
@@ -114,7 +114,15 @@ extension GameRoomViewController: UICollectionViewDataSource {
 
 extension GameRoomViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        showGameTabBarController()
+    }
     
+    private func showGameTabBarController() {
+        guard let gameTabBarController = storyboard?.instantiateViewController(withIdentifier: "GameTabBarController")
+            else { return }
+        gameTabBarController.modalTransitionStyle = .crossDissolve
+        gameTabBarController.modalPresentationStyle = .fullScreen
+        present(gameTabBarController, animated: true)
     }
 }
 

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
@@ -85,7 +85,7 @@ final class GameRoomViewController: UIViewController {
     
     private func configureUseCase() {
         GameRoomUseCase.requestGameRoom(from: GameRoomUseCase.GameRoomRequest(),
-                                        with: GameRoomUseCase.GameRoomTask(networkDispatcher: NetworkManager()))
+                                        with: GameRoomUseCase.GameRoomTask(networkDispatcher: MockGameRoomSuccess()))
         { gameRooms in
             guard let gameRooms = gameRooms else { return }
             self.gameRoomViewModels = GameRoomViewModels(gameViewModels:

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/GameRoomViewController.swift
@@ -57,6 +57,7 @@ final class GameRoomViewController: UIViewController {
             GameRoomCollectionViewFlowLayout(superFrame: view.frame))
         gameRoomCollectionView.register(GameRoomCell.self, forCellWithReuseIdentifier: GameRoomCell.reuseIdentifier)
         gameRoomCollectionView.dataSource = self
+        gameRoomCollectionView.delegate = self
         configureCollectionViewConstraints()
     }
     
@@ -108,6 +109,12 @@ extension GameRoomViewController: UICollectionViewDataSource {
             else { return GameRoomCell() }
         gameRoomCell.configure(gameRoom: gameRoomViewModel.gameRoom)
         return gameRoomCell
+    }
+}
+
+extension GameRoomViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    
     }
 }
 

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/IdentifiableViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/IdentifiableViewController.swift
@@ -1,0 +1,19 @@
+//
+//  IdentifiableViewController.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/09.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+protocol IdentifiableViewController where Self: UIViewController {
+    static var identifier: String { get }
+}
+
+extension IdentifiableViewController {
+    static var identifier: String {
+           return String(describing: self)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/LoginViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/LoginViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class LoginViewController: UIViewController {
+final class LoginViewController: UIViewController, IdentifiableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/MainViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/MainViewController.swift
@@ -23,7 +23,7 @@ final class MainViewController: UIViewController {
     }
     
     private func showLoginViewController() {
-        guard let loginViewController = storyboard?.instantiateViewController(withIdentifier: "LoginViewController") as? LoginViewController else { return }
+        guard let loginViewController = storyboard?.instantiateViewController(withIdentifier: LoginViewController.identifier) as? LoginViewController else { return }
         
         loginViewController.modalPresentationStyle = .fullScreen
         present(loginViewController, animated: false)
@@ -34,7 +34,7 @@ final class MainViewController: UIViewController {
     }
     
     private func showGameRoomViewController() {
-        guard let gameRoomViewController = storyboard?.instantiateViewController(withIdentifier: "GameRoomViewController") as? GameRoomViewController else { return }
+        guard let gameRoomViewController = storyboard?.instantiateViewController(withIdentifier: GameRoomViewController.identifier) as? GameRoomViewController else { return }
         navigationController?.pushViewController(gameRoomViewController, animated: true)
     }
 }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 final class PlayViewController: UIViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
@@ -11,5 +11,10 @@ import UIKit
 final class PlayViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureTitleView()
+    }
+    
+    private func configureTitleView() {
+        let view = Bundle.main.loadNibNamed(TitleView.identifier, owner: self, options: nil)?.first as! TitleView
     }
 }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
@@ -1,0 +1,16 @@
+//
+//  PlayViewController.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/09.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class PlayViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
@@ -15,6 +15,12 @@ final class PlayViewController: UIViewController {
     }
     
     private func configureTitleView() {
-        let view = Bundle.main.loadNibNamed(TitleView.identifier, owner: self, options: nil)?.first as! TitleView
+        let titleView = Bundle.main.loadNibNamed(TitleView.identifier, owner: self, options: nil)?.first as! TitleView
+        view.addSubview(titleView)
+        
+        titleView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
+        let safeArea = view.safeAreaLayoutGuide
+        titleView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor).isActive = true
+        titleView.topAnchor.constraint(equalTo: safeArea.topAnchor).isActive = true
     }
 }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
@@ -9,7 +9,20 @@
 import UIKit
 
 final class PlayViewController: UIViewController {
+    @IBOutlet weak var titleView: TitleView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureTitleView()
+    }
+    
+    private func configureTitleView() {
+        titleView.delegate = self
+    }
+}
+
+extension PlayViewController: TitleViewDelegate {
+    func closeButtonDidTouch() {
+        dismiss(animated: true)
     }
 }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/PlayViewController.swift
@@ -11,16 +11,5 @@ import UIKit
 final class PlayViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureTitleView()
-    }
-    
-    private func configureTitleView() {
-        let titleView = Bundle.main.loadNibNamed(TitleView.identifier, owner: self, options: nil)?.first as! TitleView
-        view.addSubview(titleView)
-        
-        titleView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
-        let safeArea = view.safeAreaLayoutGuide
-        titleView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor).isActive = true
-        titleView.topAnchor.constraint(equalTo: safeArea.topAnchor).isActive = true
     }
 }

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/ScoresViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/ScoresViewController.swift
@@ -1,0 +1,15 @@
+//
+//  ScoresViewController.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/09.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class ScoresViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/ViewControllers/ScoresViewController.swift
+++ b/iOS/BaseballGame/BaseballGame/ViewControllers/ScoresViewController.swift
@@ -9,7 +9,20 @@
 import UIKit
 
 final class ScoresViewController: UIViewController {
+    @IBOutlet weak var titleView: TitleView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureTitleView()
+    }
+    
+    private func configureTitleView() {
+        titleView.delegate = self
+    }
+}
+
+extension ScoresViewController: TitleViewDelegate {
+    func closeButtonDidTouch() {
+        dismiss(animated: true)
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
@@ -8,7 +8,13 @@
 
 import UIKit
 
+@IBDesignable
 final class ScoreView: UIView, WithXib {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        insertXibView()
+    }
+    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         insertXibView()

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
@@ -1,0 +1,13 @@
+//
+//  ScoreView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/09.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class ScoreView: UIView {
+    
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
-final class ScoreView: UIView {
-    
+final class ScoreView: UIView, WithXib {
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        insertXibView()
+    }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.xib
@@ -14,13 +14,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Captain" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ROC-oc-Qsk" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
-                    <rect key="frame" x="17.5" y="14.5" width="59" height="21"/>
+                    <rect key="frame" x="10" y="14.5" width="59" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Igj-WT-xhG" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
-                    <rect key="frame" x="99" y="14.5" width="8" height="21"/>
+                    <rect key="frame" x="127.5" y="14.5" width="8" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -32,26 +32,26 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r03-xK-7nq" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
-                    <rect key="frame" x="266.5" y="14.5" width="11" height="21"/>
+                    <rect key="frame" x="238.5" y="14.5" width="11" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Marvel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c17-Ac-Np9" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
-                    <rect key="frame" x="302" y="14.5" width="52" height="21"/>
+                    <rect key="frame" x="313" y="14.5" width="52" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="gxB-7I-ep0" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="39b-Wi-8va"/>
-                <constraint firstItem="r03-xK-7nq" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="1.45" id="3mJ-mn-Jff"/>
-                <constraint firstItem="ROC-oc-Qsk" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="0.25" id="4tO-F4-OKL"/>
-                <constraint firstItem="Igj-WT-xhG" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="0.55" id="Bek-cS-MYx"/>
-                <constraint firstItem="c17-Ac-Np9" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="1.75" id="CYy-rB-eoB"/>
+                <constraint firstItem="Igj-WT-xhG" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="0.7" id="3UB-uR-IzH"/>
                 <constraint firstItem="c17-Ac-Np9" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="GaE-do-WOA"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="c17-Ac-Np9" secondAttribute="trailing" constant="10" id="MHl-gD-iY9"/>
+                <constraint firstItem="ROC-oc-Qsk" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="10" id="PTL-QV-2Ip"/>
+                <constraint firstItem="r03-xK-7nq" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="1.3" id="TOP-gn-lY0"/>
                 <constraint firstItem="ROC-oc-Qsk" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="U83-NK-l1N"/>
                 <constraint firstItem="gxB-7I-ep0" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="b3d-CA-hnM"/>
                 <constraint firstItem="Igj-WT-xhG" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="i9P-zz-x1r"/>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.xib
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Captain" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ROC-oc-Qsk" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="17.5" y="14.5" width="59" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Igj-WT-xhG" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="99" y="14.5" width="8" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="vs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gxB-7I-ep0" customClass="VersusLabel" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="178.5" y="14.5" width="18" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r03-xK-7nq" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="266.5" y="14.5" width="11" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Marvel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c17-Ac-Np9" customClass="TitleLabel" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="302" y="14.5" width="52" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="gxB-7I-ep0" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="39b-Wi-8va"/>
+                <constraint firstItem="r03-xK-7nq" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="1.45" id="3mJ-mn-Jff"/>
+                <constraint firstItem="ROC-oc-Qsk" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="0.25" id="4tO-F4-OKL"/>
+                <constraint firstItem="Igj-WT-xhG" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="0.55" id="Bek-cS-MYx"/>
+                <constraint firstItem="c17-Ac-Np9" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="1.75" id="CYy-rB-eoB"/>
+                <constraint firstItem="c17-Ac-Np9" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="GaE-do-WOA"/>
+                <constraint firstItem="ROC-oc-Qsk" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="U83-NK-l1N"/>
+                <constraint firstItem="gxB-7I-ep0" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="b3d-CA-hnM"/>
+                <constraint firstItem="Igj-WT-xhG" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="i9P-zz-x1r"/>
+                <constraint firstItem="r03-xK-7nq" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="m8g-eO-OPp"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="138.40000000000001" y="144.82758620689657"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -14,23 +14,13 @@ protocol TitleViewDelegate {
 }
 
 final class TitleView: UIView {
-    @IBOutlet weak var closeButton: UIButton!
     var delegate: TitleViewDelegate?
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        configureCloseButton()
     }
     
-    deinit {
-        closeButton.removeTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
-    }
-    
-    private func configureCloseButton() {
-        closeButton.addTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
-    }
-    
-    @objc private func closeButtonDidTouch() {
+    @IBAction func closeButtonDidTouch(_ sender: UIButton) {
         delegate?.closeButtonDidTouch()
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -8,12 +8,29 @@
 
 import UIKit
 
+
+protocol TitleViewDelegate {
+    func closeButtonDidTouch()
+}
+
 final class TitleView: UIView {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
+    @IBOutlet weak var closeButton: UIButton!
+    var delegate: TitleViewDelegate?
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        configureCloseButton()
+    }
+    
+    deinit {
+        closeButton.removeTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
+    }
+    
+    private func configureCloseButton() {
+        closeButton.addTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
+    }
+    
+    @objc private func closeButtonDidTouch() {
+        delegate?.closeButtonDidTouch()
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -16,6 +16,11 @@ protocol TitleViewDelegate {
 final class TitleView: UIView, WithXib {
     var delegate: TitleViewDelegate?
     
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        insertXibView()
+    }
+    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         insertXibView()

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -15,18 +15,25 @@ protocol TitleViewDelegate {
 
 final class TitleView: UIView, IdentifiableView {
     var delegate: TitleViewDelegate?
-    @IBOutlet weak var closeButton: UIButton!
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        translatesAutoresizingMaskIntoConstraints = false
+        configure()
+    }
+    
+    private func configure() {
+        guard let view = loadViewFromNib() else { return }
+        view.frame = bounds
+        self.addSubview(view)
+    }
+    
+    private func loadViewFromNib() -> UIView? {
+        let bundle = Bundle(for: type(of: self))
+        let nib = UINib(nibName: TitleView.identifier, bundle: bundle)
+        return nib.instantiate(withOwner: self, options: nil).first as? UIView
     }
     
     @IBAction func closeButtonDidTouch(_ sender: UIButton) {
         delegate?.closeButtonDidTouch()
-    }
-    
-    override var intrinsicContentSize: CGSize {
-        return closeButton.intrinsicContentSize
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -15,12 +15,18 @@ protocol TitleViewDelegate {
 
 final class TitleView: UIView, IdentifiableView {
     var delegate: TitleViewDelegate?
+    @IBOutlet weak var closeButton: UIButton!
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        translatesAutoresizingMaskIntoConstraints = false
     }
     
     @IBAction func closeButtonDidTouch(_ sender: UIButton) {
         delegate?.closeButtonDidTouch()
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return closeButton.intrinsicContentSize
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -1,0 +1,19 @@
+//
+//  TitleView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/09.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class TitleView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -13,7 +13,7 @@ protocol TitleViewDelegate {
     func closeButtonDidTouch()
 }
 
-final class TitleView: UIView {
+final class TitleView: UIView, IdentifiableView {
     var delegate: TitleViewDelegate?
     
     required init?(coder: NSCoder) {

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.swift
@@ -13,24 +13,12 @@ protocol TitleViewDelegate {
     func closeButtonDidTouch()
 }
 
-final class TitleView: UIView, IdentifiableView {
+final class TitleView: UIView, WithXib {
     var delegate: TitleViewDelegate?
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        configure()
-    }
-    
-    private func configure() {
-        guard let view = loadViewFromNib() else { return }
-        view.frame = bounds
-        self.addSubview(view)
-    }
-    
-    private func loadViewFromNib() -> UIView? {
-        let bundle = Bundle(for: type(of: self))
-        let nib = UINib(nibName: TitleView.identifier, bundle: bundle)
-        return nib.instantiate(withOwner: self, options: nil).first as? UIView
+        insertXibView()
     }
     
     @IBAction func closeButtonDidTouch(_ sender: UIButton) {

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="aia-Ue-JNX">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>
+            <point key="canvasLocation" x="-134" y="-339"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -35,7 +35,6 @@
                     </connections>
                 </button>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
                 <constraint firstItem="H2w-wV-bbW" firstAttribute="leading" secondItem="m4o-rR-UdG" secondAttribute="leading" constant="15" id="Boh-be-IiS"/>
                 <constraint firstItem="iXa-Is-g9h" firstAttribute="centerX" secondItem="m4o-rR-UdG" secondAttribute="centerX" id="fpU-dw-CTd"/>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -12,10 +12,39 @@
         <view contentMode="scaleToFill" id="aia-Ue-JNX">
             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXa-Is-g9h">
+                    <rect key="frame" x="106.5" y="15" width="162.5" height="20.5"/>
+                    <attributedString key="attributedText">
+                        <fragment content="KBO Baseball game">
+                            <attributes>
+                                <color key="NSColor" red="0.050980392156862744" green="0.16078431372549018" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <font key="NSFont" size="17" name="HelveticaNeue-BoldItalic"/>
+                                <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                            </attributes>
+                        </fragment>
+                    </attributedString>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H2w-wV-bbW">
+                    <rect key="frame" x="15" y="14" width="18" height="22"/>
+                    <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <state key="normal" image="xmark" catalog="system"/>
+                </button>
+            </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="H2w-wV-bbW" firstAttribute="leading" secondItem="m4o-rR-UdG" secondAttribute="leading" constant="15" id="Boh-be-IiS"/>
+                <constraint firstItem="iXa-Is-g9h" firstAttribute="centerX" secondItem="m4o-rR-UdG" secondAttribute="centerX" id="fpU-dw-CTd"/>
+                <constraint firstItem="iXa-Is-g9h" firstAttribute="centerY" secondItem="m4o-rR-UdG" secondAttribute="centerY" id="jP2-gN-nUR"/>
+                <constraint firstItem="H2w-wV-bbW" firstAttribute="centerY" secondItem="m4o-rR-UdG" secondAttribute="centerY" id="zHN-5w-XX8"/>
+            </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>
             <point key="canvasLocation" x="-134" y="-339"/>
         </view>
     </objects>
+    <resources>
+        <image name="xmark" catalog="system" width="128" height="113"/>
+    </resources>
 </document>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -7,14 +7,14 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="aia-Ue-JNX" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+        <view contentMode="scaleToFill" id="aia-Ue-JNX">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXa-Is-g9h">
-                    <rect key="frame" x="106.5" y="15" width="162.5" height="20.5"/>
+                    <rect key="frame" x="106.5" y="2.5" width="162.5" height="20.5"/>
                     <attributedString key="attributedText">
                         <fragment content="KBO Baseball game">
                             <attributes>
@@ -27,11 +27,11 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H2w-wV-bbW">
-                    <rect key="frame" x="15" y="14" width="18" height="22"/>
+                    <rect key="frame" x="15" y="1.5" width="18" height="22"/>
                     <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" image="xmark" catalog="system"/>
                     <connections>
-                        <action selector="closeButtonDidTouch:" destination="aia-Ue-JNX" eventType="touchUpInside" id="0yc-dh-yao"/>
+                        <action selector="closeButtonDidTouch:" destination="-1" eventType="touchUpInside" id="sNq-rD-OCt"/>
                     </connections>
                 </button>
             </subviews>
@@ -44,9 +44,6 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>
-            <connections>
-                <outlet property="closeButton" destination="H2w-wV-bbW" id="i7m-u9-gcV"/>
-            </connections>
             <point key="canvasLocation" x="-135.19999999999999" y="-339.13043478260875"/>
         </view>
     </objects>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -27,7 +27,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H2w-wV-bbW">
-                    <rect key="frame" x="15" y="1.5" width="18" height="22"/>
+                    <rect key="frame" x="5" y="3" width="18" height="22"/>
                     <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" image="xmark" catalog="system"/>
                     <connections>
@@ -35,11 +35,12 @@
                     </connections>
                 </button>
             </subviews>
+            <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="H2w-wV-bbW" firstAttribute="leading" secondItem="m4o-rR-UdG" secondAttribute="leading" constant="15" id="Boh-be-IiS"/>
+                <constraint firstItem="H2w-wV-bbW" firstAttribute="leading" secondItem="m4o-rR-UdG" secondAttribute="leading" constant="5" id="Boh-be-IiS"/>
                 <constraint firstItem="iXa-Is-g9h" firstAttribute="centerX" secondItem="m4o-rR-UdG" secondAttribute="centerX" id="fpU-dw-CTd"/>
                 <constraint firstItem="iXa-Is-g9h" firstAttribute="centerY" secondItem="m4o-rR-UdG" secondAttribute="centerY" id="jP2-gN-nUR"/>
-                <constraint firstItem="H2w-wV-bbW" firstAttribute="centerY" secondItem="m4o-rR-UdG" secondAttribute="centerY" id="zHN-5w-XX8"/>
+                <constraint firstItem="H2w-wV-bbW" firstAttribute="centerY" secondItem="m4o-rR-UdG" secondAttribute="centerY" multiplier="1.1" id="zHN-5w-XX8"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -10,11 +10,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="aia-Ue-JNX">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXa-Is-g9h">
-                    <rect key="frame" x="106.5" y="2.5" width="162.5" height="20.5"/>
+                    <rect key="frame" x="106.5" y="15" width="162.5" height="20.5"/>
                     <attributedString key="attributedText">
                         <fragment content="KBO Baseball game">
                             <attributes>
@@ -27,7 +27,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H2w-wV-bbW">
-                    <rect key="frame" x="5" y="3" width="18" height="22"/>
+                    <rect key="frame" x="5" y="16.5" width="18" height="22"/>
                     <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" image="xmark" catalog="system"/>
                     <connections>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -30,6 +30,9 @@
                     <rect key="frame" x="15" y="14" width="18" height="22"/>
                     <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" image="xmark" catalog="system"/>
+                    <connections>
+                        <action selector="closeButtonDidTouch:" destination="aia-Ue-JNX" eventType="touchUpInside" id="0yc-dh-yao"/>
+                    </connections>
                 </button>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -41,9 +44,6 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>
-            <connections>
-                <outlet property="closeButton" destination="H2w-wV-bbW" id="ToC-ji-J0R"/>
-            </connections>
             <point key="canvasLocation" x="-135.19999999999999" y="-339.13043478260875"/>
         </view>
     </objects>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="aia-Ue-JNX">
+        <view contentMode="scaleToFill" id="aia-Ue-JNX" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -41,7 +41,10 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>
-            <point key="canvasLocation" x="-134" y="-339"/>
+            <connections>
+                <outlet property="closeButton" destination="H2w-wV-bbW" id="ToC-ji-J0R"/>
+            </connections>
+            <point key="canvasLocation" x="-135.19999999999999" y="-339.13043478260875"/>
         </view>
     </objects>
     <resources>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -44,6 +44,9 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="m4o-rR-UdG"/>
+            <connections>
+                <outlet property="closeButton" destination="H2w-wV-bbW" id="i7m-u9-gcV"/>
+            </connections>
             <point key="canvasLocation" x="-135.19999999999999" y="-339.13043478260875"/>
         </view>
     </objects>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/TitleView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -10,7 +10,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="aia-Ue-JNX">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/iOS/BaseballGame/BaseballGame/Views/GameRoom/GameRoomCell.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/GameRoom/GameRoomCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class GameRoomCell: UICollectionViewCell, ReusableView {
+final class GameRoomCell: UICollectionViewCell, IdentifiableView {
     private let gameRoomLabel = GameRoomLabel()
     private let versusLabel = VersusLabel()
     private let awayTeamLabel = TitleLabel()

--- a/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
@@ -36,11 +36,11 @@ final class PrevButton: UIButton {
     }
     
     private func configureTarget() {
-        addTarget(self, action: #selector(buttonDidTouch), for: .touchUpInside)
+        addTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
     }
     
     deinit {
-        removeTarget(self, action: #selector(buttonDidTouch), for: .touchUpInside)
+        removeTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
     }
     
     @objc private func buttonDidTouch() {

--- a/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
@@ -36,14 +36,14 @@ final class PrevButton: UIButton {
     }
     
     private func configureTarget() {
-        addTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
+        addTarget(self, action: #selector(prevButtonDidTouch), for: .touchUpInside)
     }
     
     deinit {
-        removeTarget(self, action: #selector(closeButtonDidTouch), for: .touchUpInside)
+        removeTarget(self, action: #selector(prevButtonDidTouch), for: .touchUpInside)
     }
     
-    @objc private func buttonDidTouch() {
+    @objc private func prevButtonDidTouch() {
         delegate?.prevButtonDidTouch()
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
@@ -30,7 +30,7 @@ final class PrevButton: UIButton {
     
     private func confugure() {
         setImage(UIImage(systemName: "arrow.left"), for: .normal)
-        tintColor = .red
+        tintColor = .systemRed
         imageView?.contentMode = .scaleAspectFit
         imageEdgeInsets = UIEdgeInsets(top: 23, left: 23, bottom: 23, right: 23)
     }

--- a/iOS/BaseballGame/BaseballGame/Views/IdentifiableView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/IdentifiableView.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-protocol ReusableView where Self: UIView {
-    static var reuseIdentifier: String { get }
+protocol IdentifiableView where Self: UIView {
+    static var identifier: String { get }
 }
 
-extension ReusableView {
-    static var reuseIdentifier: String {
+extension IdentifiableView {
+    static var identifier: String {
            return String(describing: self)
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/IdentifiableView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/IdentifiableView.swift
@@ -17,3 +17,17 @@ extension IdentifiableView {
            return String(describing: self)
     }
 }
+
+protocol WithXib: IdentifiableView {
+    func insertXibView()
+}
+
+extension WithXib {
+    func insertXibView() {
+        let bundle = Bundle(for: type(of: self))
+        let nib = UINib(nibName: Self.identifier, bundle: bundle)
+        guard let view =  nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
+        view.frame = bounds
+        self.addSubview(view)
+    }
+}


### PR DESCRIPTION
이슈 #35 을 해결하였습니다. 

* TitleView와 ScoresView를 xib를 이용해 재사용해보았습니다.
  * 각 CustomView가 xib의 주인(Owner)가 되고, xib의 first 뷰를 불러와 각 CustomView를 꽉 채우는 식으로 구현하였습니다. 
  * `@IBDesignable`을 이용해서 ScoresView가 보이도록 하였습니다. TitleView도 적용하고 싶었는데, 스토리보드에서 깨져보여서 취소하였습니다. 
    * `@IBDesignable`이 init(frame)을 override 해야하고, 번들을 메인에서 하지 말아야지만 에러가 안나고 잘 적용됨을 알수 있었는데 이유는 모르겠습니다. 이유를 나중에 알아보도록 하겠습니다. 

* 탭바에 적절한 SFSymbols를 추가하였습니다.

> 실행화면 

* PlayViewController
<img width="300" alt="playvc" src="https://user-images.githubusercontent.com/38216027/81471991-24b2bb00-9230-11ea-9763-17748e71c3d5.png">

* ScoreViewController
<img width="300" alt="scorevc" src="https://user-images.githubusercontent.com/38216027/81471994-2a100580-9230-11ea-966b-3eb44b2149c7.png">

