### PR TITLE
[iOS][#5] 게임 진행화면 뷰를 구성하였습니다. 

### DIFF
--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A481FC62467CB6300BBDC00 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC52467CB6300BBDC00 /* BoardView.swift */; };
 		5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50924601708002ECB3A /* AppDelegate.swift */; };
 		5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50B24601708002ECB3A /* SceneDelegate.swift */; };
 		5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */; };
@@ -73,6 +74,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5A481FC52467CB6300BBDC00 /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
 		5A7DD50624601708002ECB3A /* BaseballGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseballGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A7DD50924601708002ECB3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5A7DD50B24601708002ECB3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				5A89B6572467B7C900AA82F1 /* SBOView.xib */,
 				5A89B6592467BD0600AA82F1 /* SBOView.swift */,
 				5A89B65B2467C85C00AA82F1 /* SBOsView.swift */,
+				5A481FC52467CB6300BBDC00 /* BoardView.swift */,
 			);
 			path = Play;
 			sourceTree = "<group>";
@@ -488,6 +491,7 @@
 				5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */,
 				5A814EF824629BF7001C768D /* NetworkDispatcher.swift in Sources */,
 				5A814F702466AC9A001C768D /* ScoreView.swift in Sources */,
+				5A481FC62467CB6300BBDC00 /* BoardView.swift in Sources */,
 				5A814F6824665B23001C768D /* TitleView.swift in Sources */,
 				5A814F0A2462AD99001C768D /* MockGameRoomSuccess.swift in Sources */,
 				5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -50,8 +50,9 @@
 		5A814F702466AC9A001C768D /* ScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6F2466AC9A001C768D /* ScoreView.swift */; };
 		5A814F722466ACB0001C768D /* ScoreView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F712466ACB0001C768D /* ScoreView.xib */; };
 		5A89B6562467B4DD00AA82F1 /* BoardLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */; };
-		5A89B6582467B7C900AA82F1 /* CountView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A89B6572467B7C900AA82F1 /* CountView.xib */; };
-		5A89B65A2467BD0600AA82F1 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B6592467BD0600AA82F1 /* CountView.swift */; };
+		5A89B6582467B7C900AA82F1 /* SBOView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A89B6572467B7C900AA82F1 /* SBOView.xib */; };
+		5A89B65A2467BD0600AA82F1 /* SBOView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B6592467BD0600AA82F1 /* SBOView.swift */; };
+		5A89B65C2467C85C00AA82F1 /* SBOsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B65B2467C85C00AA82F1 /* SBOsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,8 +122,9 @@
 		5A814F6F2466AC9A001C768D /* ScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreView.swift; sourceTree = "<group>"; };
 		5A814F712466ACB0001C768D /* ScoreView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ScoreView.xib; sourceTree = "<group>"; };
 		5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardLabel.swift; sourceTree = "<group>"; };
-		5A89B6572467B7C900AA82F1 /* CountView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CountView.xib; sourceTree = "<group>"; };
-		5A89B6592467BD0600AA82F1 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountView.swift; sourceTree = "<group>"; };
+		5A89B6572467B7C900AA82F1 /* SBOView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SBOView.xib; sourceTree = "<group>"; };
+		5A89B6592467BD0600AA82F1 /* SBOView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBOView.swift; sourceTree = "<group>"; };
+		5A89B65B2467C85C00AA82F1 /* SBOsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBOsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -337,8 +339,9 @@
 			isa = PBXGroup;
 			children = (
 				5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */,
-				5A89B6572467B7C900AA82F1 /* CountView.xib */,
-				5A89B6592467BD0600AA82F1 /* CountView.swift */,
+				5A89B6572467B7C900AA82F1 /* SBOView.xib */,
+				5A89B6592467BD0600AA82F1 /* SBOView.swift */,
+				5A89B65B2467C85C00AA82F1 /* SBOsView.swift */,
 			);
 			path = Play;
 			sourceTree = "<group>";
@@ -451,7 +454,7 @@
 				5A814F722466ACB0001C768D /* ScoreView.xib in Resources */,
 				5A7DD5132460170A002ECB3A /* Assets.xcassets in Resources */,
 				5A814F6424658E25001C768D /* TitleView.xib in Resources */,
-				5A89B6582467B7C900AA82F1 /* CountView.xib in Resources */,
+				5A89B6582467B7C900AA82F1 /* SBOView.xib in Resources */,
 				5A814EE924627B5B001C768D /* TeamInfoSuccessStub.json in Resources */,
 				5A7DD51124601708002ECB3A /* Main.storyboard in Resources */,
 			);
@@ -503,6 +506,7 @@
 				5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */,
 				5A814F55246439B2001C768D /* BorderedButton.swift in Sources */,
 				5A814EF224627EB0001C768D /* GameRoom.swift in Sources */,
+				5A89B65C2467C85C00AA82F1 /* SBOsView.swift in Sources */,
 				5A814F6024645F07001C768D /* PrevButton.swift in Sources */,
 				5A814F5A24644B15001C768D /* OauthLoginButton.swift in Sources */,
 				5A814EF62462810B001C768D /* Request.swift in Sources */,
@@ -510,7 +514,7 @@
 				5A814F5824643A9D001C768D /* UIColorExtension.swift in Sources */,
 				5A814F032462AB84001C768D /* GameRoomUseCase.swift in Sources */,
 				5A814F122462DEDF001C768D /* ViewModelBinding.swift in Sources */,
-				5A89B65A2467BD0600AA82F1 /* CountView.swift in Sources */,
+				5A89B65A2467BD0600AA82F1 /* SBOView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		5A481FC62467CB6300BBDC00 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC52467CB6300BBDC00 /* BoardView.swift */; };
+		5A481FC82467CEF600BBDC00 /* CurrentPlayerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */; };
+		5A481FCA2467D6B100BBDC00 /* PlayTableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */; };
 		5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50924601708002ECB3A /* AppDelegate.swift */; };
 		5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50B24601708002ECB3A /* SceneDelegate.swift */; };
 		5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */; };
@@ -75,6 +77,8 @@
 
 /* Begin PBXFileReference section */
 		5A481FC52467CB6300BBDC00 /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
+		5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPlayerCell.swift; sourceTree = "<group>"; };
+		5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTableLabel.swift; sourceTree = "<group>"; };
 		5A7DD50624601708002ECB3A /* BaseballGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseballGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A7DD50924601708002ECB3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5A7DD50B24601708002ECB3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -345,6 +349,8 @@
 				5A89B6592467BD0600AA82F1 /* SBOView.swift */,
 				5A89B65B2467C85C00AA82F1 /* SBOsView.swift */,
 				5A481FC52467CB6300BBDC00 /* BoardView.swift */,
+				5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */,
+				5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */,
 			);
 			path = Play;
 			sourceTree = "<group>";
@@ -484,6 +490,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A481FCA2467D6B100BBDC00 /* PlayTableLabel.swift in Sources */,
 				5A814F102462DED2001C768D /* GameRoomViewModel.swift in Sources */,
 				5A7DD54624603A0E002ECB3A /* VersusLabel.swift in Sources */,
 				5A814EED24627BD5001C768D /* DataExtensions.swift in Sources */,
@@ -502,6 +509,7 @@
 				5A814F6A246664DE001C768D /* PlayViewController.swift in Sources */,
 				5A814F532464016D001C768D /* IdentifiableView.swift in Sources */,
 				5A814F5C24645052001C768D /* LoginViewController.swift in Sources */,
+				5A481FC82467CEF600BBDC00 /* CurrentPlayerCell.swift in Sources */,
 				5A7DD54C246056AD002ECB3A /* GameRoomViewModels.swift in Sources */,
 				5A814F5E246451B2001C768D /* MainViewController.swift in Sources */,
 				5A89B6562467B4DD00AA82F1 /* BoardLabel.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		5A481FC62467CB6300BBDC00 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC52467CB6300BBDC00 /* BoardView.swift */; };
 		5A481FC82467CEF600BBDC00 /* CurrentPlayerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */; };
 		5A481FCA2467D6B100BBDC00 /* PlayTableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */; };
+		5A481FCC2467DCA200BBDC00 /* PitchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCB2467DCA200BBDC00 /* PitchButton.swift */; };
 		5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50924601708002ECB3A /* AppDelegate.swift */; };
 		5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50B24601708002ECB3A /* SceneDelegate.swift */; };
 		5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */; };
@@ -79,6 +80,7 @@
 		5A481FC52467CB6300BBDC00 /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
 		5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPlayerCell.swift; sourceTree = "<group>"; };
 		5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTableLabel.swift; sourceTree = "<group>"; };
+		5A481FCB2467DCA200BBDC00 /* PitchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchButton.swift; sourceTree = "<group>"; };
 		5A7DD50624601708002ECB3A /* BaseballGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseballGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A7DD50924601708002ECB3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5A7DD50B24601708002ECB3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				5A481FC52467CB6300BBDC00 /* BoardView.swift */,
 				5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */,
 				5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */,
+				5A481FCB2467DCA200BBDC00 /* PitchButton.swift */,
 			);
 			path = Play;
 			sourceTree = "<group>";
@@ -518,6 +521,7 @@
 				5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */,
 				5A814F55246439B2001C768D /* BorderedButton.swift in Sources */,
 				5A814EF224627EB0001C768D /* GameRoom.swift in Sources */,
+				5A481FCC2467DCA200BBDC00 /* PitchButton.swift in Sources */,
 				5A89B65C2467C85C00AA82F1 /* SBOsView.swift in Sources */,
 				5A814F6024645F07001C768D /* PrevButton.swift in Sources */,
 				5A814F5A24644B15001C768D /* OauthLoginButton.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		5A481FC82467CEF600BBDC00 /* CurrentPlayerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */; };
 		5A481FCA2467D6B100BBDC00 /* PlayTableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */; };
 		5A481FCC2467DCA200BBDC00 /* PitchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCB2467DCA200BBDC00 /* PitchButton.swift */; };
+		5A481FCE2467E0BC00BBDC00 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCD2467E0BC00BBDC00 /* CountView.swift */; };
 		5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50924601708002ECB3A /* AppDelegate.swift */; };
 		5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50B24601708002ECB3A /* SceneDelegate.swift */; };
 		5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */; };
@@ -81,6 +82,7 @@
 		5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPlayerCell.swift; sourceTree = "<group>"; };
 		5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTableLabel.swift; sourceTree = "<group>"; };
 		5A481FCB2467DCA200BBDC00 /* PitchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchButton.swift; sourceTree = "<group>"; };
+		5A481FCD2467E0BC00BBDC00 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountView.swift; sourceTree = "<group>"; };
 		5A7DD50624601708002ECB3A /* BaseballGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseballGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A7DD50924601708002ECB3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5A7DD50B24601708002ECB3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */,
 				5A89B6572467B7C900AA82F1 /* SBOView.xib */,
 				5A89B6592467BD0600AA82F1 /* SBOView.swift */,
+				5A481FCD2467E0BC00BBDC00 /* CountView.swift */,
 				5A89B65B2467C85C00AA82F1 /* SBOsView.swift */,
 				5A481FC52467CB6300BBDC00 /* BoardView.swift */,
 				5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */,
@@ -519,6 +522,7 @@
 				5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */,
 				5A7DD54224603715002ECB3A /* GameRoomLabel.swift in Sources */,
 				5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */,
+				5A481FCE2467E0BC00BBDC00 /* CountView.swift in Sources */,
 				5A814F55246439B2001C768D /* BorderedButton.swift in Sources */,
 				5A814EF224627EB0001C768D /* GameRoom.swift in Sources */,
 				5A481FCC2467DCA200BBDC00 /* PitchButton.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		5A814F6E24669226001C768D /* IdentifiableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6D24669226001C768D /* IdentifiableViewController.swift */; };
 		5A814F702466AC9A001C768D /* ScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6F2466AC9A001C768D /* ScoreView.swift */; };
 		5A814F722466ACB0001C768D /* ScoreView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F712466ACB0001C768D /* ScoreView.xib */; };
+		5A89B6562467B4DD00AA82F1 /* BoardLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -117,6 +118,7 @@
 		5A814F6D24669226001C768D /* IdentifiableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableViewController.swift; sourceTree = "<group>"; };
 		5A814F6F2466AC9A001C768D /* ScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreView.swift; sourceTree = "<group>"; };
 		5A814F712466ACB0001C768D /* ScoreView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ScoreView.xib; sourceTree = "<group>"; };
+		5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardLabel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -318,12 +320,21 @@
 		5A814F6624665A07001C768D /* Game */ = {
 			isa = PBXGroup;
 			children = (
+				5A89B6542467B4BE00AA82F1 /* Play */,
 				5A814F6324658E25001C768D /* TitleView.xib */,
 				5A814F6724665B23001C768D /* TitleView.swift */,
 				5A814F6F2466AC9A001C768D /* ScoreView.swift */,
 				5A814F712466ACB0001C768D /* ScoreView.xib */,
 			);
 			path = Game;
+			sourceTree = "<group>";
+		};
+		5A89B6542467B4BE00AA82F1 /* Play */ = {
+			isa = PBXGroup;
+			children = (
+				5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */,
+			);
+			path = Play;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -479,6 +490,7 @@
 				5A814F5C24645052001C768D /* LoginViewController.swift in Sources */,
 				5A7DD54C246056AD002ECB3A /* GameRoomViewModels.swift in Sources */,
 				5A814F5E246451B2001C768D /* MainViewController.swift in Sources */,
+				5A89B6562467B4DD00AA82F1 /* BoardLabel.swift in Sources */,
 				5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */,
 				5A7DD54224603715002ECB3A /* GameRoomLabel.swift in Sources */,
 				5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		5A814F702466AC9A001C768D /* ScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814F6F2466AC9A001C768D /* ScoreView.swift */; };
 		5A814F722466ACB0001C768D /* ScoreView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A814F712466ACB0001C768D /* ScoreView.xib */; };
 		5A89B6562467B4DD00AA82F1 /* BoardLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */; };
+		5A89B6582467B7C900AA82F1 /* CountView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A89B6572467B7C900AA82F1 /* CountView.xib */; };
+		5A89B65A2467BD0600AA82F1 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89B6592467BD0600AA82F1 /* CountView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,6 +121,8 @@
 		5A814F6F2466AC9A001C768D /* ScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreView.swift; sourceTree = "<group>"; };
 		5A814F712466ACB0001C768D /* ScoreView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ScoreView.xib; sourceTree = "<group>"; };
 		5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardLabel.swift; sourceTree = "<group>"; };
+		5A89B6572467B7C900AA82F1 /* CountView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CountView.xib; sourceTree = "<group>"; };
+		5A89B6592467BD0600AA82F1 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -333,6 +337,8 @@
 			isa = PBXGroup;
 			children = (
 				5A89B6552467B4DD00AA82F1 /* BoardLabel.swift */,
+				5A89B6572467B7C900AA82F1 /* CountView.xib */,
+				5A89B6592467BD0600AA82F1 /* CountView.swift */,
 			);
 			path = Play;
 			sourceTree = "<group>";
@@ -445,6 +451,7 @@
 				5A814F722466ACB0001C768D /* ScoreView.xib in Resources */,
 				5A7DD5132460170A002ECB3A /* Assets.xcassets in Resources */,
 				5A814F6424658E25001C768D /* TitleView.xib in Resources */,
+				5A89B6582467B7C900AA82F1 /* CountView.xib in Resources */,
 				5A814EE924627B5B001C768D /* TeamInfoSuccessStub.json in Resources */,
 				5A7DD51124601708002ECB3A /* Main.storyboard in Resources */,
 			);
@@ -503,6 +510,7 @@
 				5A814F5824643A9D001C768D /* UIColorExtension.swift in Sources */,
 				5A814F032462AB84001C768D /* GameRoomUseCase.swift in Sources */,
 				5A814F122462DEDF001C768D /* ViewModelBinding.swift in Sources */,
+				5A89B65A2467BD0600AA82F1 /* CountView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5A481FCC2467DCA200BBDC00 /* PitchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCB2467DCA200BBDC00 /* PitchButton.swift */; };
 		5A481FCE2467E0BC00BBDC00 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCD2467E0BC00BBDC00 /* CountView.swift */; };
 		5A481FD02467F9D600BBDC00 /* BatterInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCF2467F9D600BBDC00 /* BatterInfoCell.swift */; };
+		5A481FD22467FBC700BBDC00 /* OrderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FD12467FBC700BBDC00 /* OrderLabel.swift */; };
 		5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50924601708002ECB3A /* AppDelegate.swift */; };
 		5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50B24601708002ECB3A /* SceneDelegate.swift */; };
 		5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */; };
@@ -85,6 +86,7 @@
 		5A481FCB2467DCA200BBDC00 /* PitchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchButton.swift; sourceTree = "<group>"; };
 		5A481FCD2467E0BC00BBDC00 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountView.swift; sourceTree = "<group>"; };
 		5A481FCF2467F9D600BBDC00 /* BatterInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatterInfoCell.swift; sourceTree = "<group>"; };
+		5A481FD12467FBC700BBDC00 /* OrderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderLabel.swift; sourceTree = "<group>"; };
 		5A7DD50624601708002ECB3A /* BaseballGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseballGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A7DD50924601708002ECB3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5A7DD50B24601708002ECB3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -360,6 +362,7 @@
 				5A481FCF2467F9D600BBDC00 /* BatterInfoCell.swift */,
 				5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */,
 				5A481FCB2467DCA200BBDC00 /* PitchButton.swift */,
+				5A481FD12467FBC700BBDC00 /* OrderLabel.swift */,
 			);
 			path = Play;
 			sourceTree = "<group>";
@@ -520,6 +523,7 @@
 				5A814F532464016D001C768D /* IdentifiableView.swift in Sources */,
 				5A814F5C24645052001C768D /* LoginViewController.swift in Sources */,
 				5A481FC82467CEF600BBDC00 /* CurrentPlayerCell.swift in Sources */,
+				5A481FD22467FBC700BBDC00 /* OrderLabel.swift in Sources */,
 				5A7DD54C246056AD002ECB3A /* GameRoomViewModels.swift in Sources */,
 				5A814F5E246451B2001C768D /* MainViewController.swift in Sources */,
 				5A89B6562467B4DD00AA82F1 /* BoardLabel.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
+++ b/iOS/BaseballGame/BaseballGame.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5A481FCA2467D6B100BBDC00 /* PlayTableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */; };
 		5A481FCC2467DCA200BBDC00 /* PitchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCB2467DCA200BBDC00 /* PitchButton.swift */; };
 		5A481FCE2467E0BC00BBDC00 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCD2467E0BC00BBDC00 /* CountView.swift */; };
+		5A481FD02467F9D600BBDC00 /* BatterInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A481FCF2467F9D600BBDC00 /* BatterInfoCell.swift */; };
 		5A7DD50A24601708002ECB3A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50924601708002ECB3A /* AppDelegate.swift */; };
 		5A7DD50C24601708002ECB3A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50B24601708002ECB3A /* SceneDelegate.swift */; };
 		5A7DD50E24601708002ECB3A /* GameRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7DD50D24601708002ECB3A /* GameRoomViewController.swift */; };
@@ -83,6 +84,7 @@
 		5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTableLabel.swift; sourceTree = "<group>"; };
 		5A481FCB2467DCA200BBDC00 /* PitchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchButton.swift; sourceTree = "<group>"; };
 		5A481FCD2467E0BC00BBDC00 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountView.swift; sourceTree = "<group>"; };
+		5A481FCF2467F9D600BBDC00 /* BatterInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatterInfoCell.swift; sourceTree = "<group>"; };
 		5A7DD50624601708002ECB3A /* BaseballGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaseballGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A7DD50924601708002ECB3A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5A7DD50B24601708002ECB3A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -355,6 +357,7 @@
 				5A89B65B2467C85C00AA82F1 /* SBOsView.swift */,
 				5A481FC52467CB6300BBDC00 /* BoardView.swift */,
 				5A481FC72467CEF600BBDC00 /* CurrentPlayerCell.swift */,
+				5A481FCF2467F9D600BBDC00 /* BatterInfoCell.swift */,
 				5A481FC92467D6B100BBDC00 /* PlayTableLabel.swift */,
 				5A481FCB2467DCA200BBDC00 /* PitchButton.swift */,
 			);
@@ -501,6 +504,7 @@
 				5A7DD54624603A0E002ECB3A /* VersusLabel.swift in Sources */,
 				5A814EED24627BD5001C768D /* DataExtensions.swift in Sources */,
 				5A7DD54A24604DE9002ECB3A /* GameRoomCollectionView.swift in Sources */,
+				5A481FD02467F9D600BBDC00 /* BatterInfoCell.swift in Sources */,
 				5A814F6C24666502001C768D /* ScoresViewController.swift in Sources */,
 				5A814EF824629BF7001C768D /* NetworkDispatcher.swift in Sources */,
 				5A814F702466AC9A001C768D /* ScoreView.swift in Sources */,

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -257,14 +257,24 @@
                                     <constraint firstAttribute="width" secondItem="jpd-qi-a5W" secondAttribute="height" multiplier="9:1" id="GjB-B1-QwW"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View">
+                                <rect key="frame" x="0.0" y="63.5" width="375" height="250"/>
+                                <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="top" secondItem="Hvq-eV-AVL" secondAttribute="top" id="0mA-Nc-q4r"/>
+                            <constraint firstItem="2fF-x6-cX0" firstAttribute="top" secondItem="jpd-qi-a5W" secondAttribute="bottom" id="687-0S-JeW"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Bc8-Eg-gBM"/>
+                            <constraint firstItem="2fF-x6-cX0" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="T70-vn-72c"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="Tre-pF-HCn"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Wwo-Lt-iZX"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dDA-x6-gdQ"/>
+                            <constraint firstItem="2fF-x6-cX0" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="ghc-Z8-Mx1"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="top" secondItem="aSi-rk-FUG" secondAttribute="bottom" id="n8k-hw-9jE"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -405,6 +405,16 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb" userLabel="Batter Info Table">
                                 <rect key="frame" x="0.0" y="432" width="375" height="186"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="BatterInfoCell" id="xPN-eW-c5v">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xPN-eW-c5v" id="604-6f-aKH">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="NiE-Ip-oQf">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -11,7 +12,7 @@
             <objects>
                 <viewController storyboardIdentifier="GameRoomViewController" id="xl2-2U-nfi" customClass="GameRoomViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mJ7-rS-pgE">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <viewLayoutGuide key="safeArea" id="Wny-TU-azI"/>
@@ -26,17 +27,17 @@
             <objects>
                 <viewController id="4qG-2e-g0p" customClass="MainViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cOi-Ug-8eN">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="batter" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-VR-5Nb">
-                                <rect key="frame" x="51" y="-69" width="498" height="498"/>
+                                <rect key="frame" x="32" y="44.5" width="311" height="311"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="zK2-VR-5Nb" secondAttribute="height" multiplier="1:1" id="3iZ-3E-7dH"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yIB-ep-Rll">
-                                <rect key="frame" x="142.5" y="422" width="315" height="39.5"/>
+                                <rect key="frame" x="30" y="348.5" width="315" height="39.5"/>
                                 <attributedString key="attributedText">
                                     <fragment content="KBO Baseball game">
                                         <attributes>
@@ -49,7 +50,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q5p-zu-nMg" customClass="BorderedButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="15" y="491.5" width="570" height="40"/>
+                                <rect key="frame" x="15" y="418" width="345" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="bJR-rf-Q6X"/>
                                 </constraints>
@@ -61,7 +62,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IjI-2N-etU" customClass="BorderedButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="15" y="546.5" width="570" height="40"/>
+                                <rect key="frame" x="15" y="473" width="345" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="zzB-Tk-QKR"/>
                                 </constraints>
@@ -97,22 +98,22 @@
             <objects>
                 <viewController storyboardIdentifier="LoginViewController" id="QXQ-4t-51P" customClass="LoginViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Nyt-ff-rlX">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="아이디 또는 이메일" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="wVr-Uk-bIh" userLabel="IDTextField">
-                                <rect key="frame" x="15" y="208" width="570" height="34"/>
+                                <rect key="frame" x="15" y="233" width="345" height="34"/>
                                 <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="비밀번호" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3IV-7t-fDh" userLabel="PasswordTextField">
-                                <rect key="frame" x="15" y="257" width="570" height="34"/>
+                                <rect key="frame" x="15" y="282" width="345" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xUP-YI-cXb" customClass="BorderedButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="15" y="306" width="570" height="40"/>
+                                <rect key="frame" x="15" y="331" width="345" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="ZiL-lF-Vkn"/>
                                 </constraints>
@@ -121,27 +122,27 @@
                                 <state key="normal" title="로그인"/>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2bj-KN-3QL">
-                                <rect key="frame" x="291" y="361" width="18" height="23"/>
+                                <rect key="frame" x="178.5" y="386" width="18" height="23"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <color key="textColor" cocoaTouchSystemColor="scrollViewTexturedBackgroundColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a0j-wY-PSj">
-                                <rect key="frame" x="15" y="372" width="252" height="1"/>
+                                <rect key="frame" x="15" y="397" width="157.5" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="l0X-KA-495"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8s-Zd-lZ4">
-                                <rect key="frame" x="333" y="372" width="252" height="1"/>
+                                <rect key="frame" x="202.5" y="397" width="157.5" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="zQS-fI-m2M"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xYD-5F-1kT" customClass="OauthLoginButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="221" y="399" width="158.5" height="22"/>
+                                <rect key="frame" x="108.5" y="424" width="158.5" height="22"/>
                                 <state key="normal" title="Github으로 로그인" image="github">
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
@@ -150,7 +151,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wys-LL-uxP">
-                                <rect key="frame" x="142.5" y="128.5" width="315" height="39.5"/>
+                                <rect key="frame" x="30" y="153.5" width="315" height="39.5"/>
                                 <attributedString key="attributedText">
                                     <fragment content="KBO Baseball game">
                                         <attributes>
@@ -199,17 +200,17 @@
             <objects>
                 <viewController id="qaG-7m-vvT" customClass="ScoresViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aJF-G8-Naq">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mBQ-yj-4gl" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="35.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="mBQ-yj-4gl" secondAttribute="height" multiplier="17:1" id="lJz-Oj-Lis"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hYS-x3-cZA" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="35.5" width="600" height="66.5"/>
+                                <rect key="frame" x="0.0" y="22" width="375" height="41.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="hYS-x3-cZA" secondAttribute="height" multiplier="9:1" id="yLB-Fz-PLB"/>
@@ -241,34 +242,34 @@
             <objects>
                 <viewController id="cSG-l2-sFt" customClass="PlayViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kMd-Vk-jkA">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aSi-rk-FUG" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="35.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="aSi-rk-FUG" secondAttribute="height" multiplier="17:1" id="yiO-X5-Xao"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jpd-qi-a5W" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="35.5" width="600" height="66.5"/>
+                                <rect key="frame" x="0.0" y="22" width="375" height="41.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="jpd-qi-a5W" secondAttribute="height" multiplier="9:1" id="GjB-B1-QwW"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View">
-                                <rect key="frame" x="0.0" y="63.5" width="600" height="250"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View" customClass="BoardView" customModule="BaseballGame" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="63.5" width="375" height="250"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" userLabel="Board Counts View" customClass="SBOsView" customModule="BaseballGame" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" customClass="SBOsView" customModule="BaseballGame" customModuleProvider="target">
                                         <rect key="frame" x="15" y="15" width="97.5" height="75"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nVw-tg-xeD" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nVw-tg-xeD" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="97.5" height="25"/>
                                             </view>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3ii-ab-PXe" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3ii-ab-PXe" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="25" width="97.5" height="24.5"/>
                                             </view>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ztM-E3-dzb" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ztM-E3-dzb" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="49.5" width="97.5" height="25"/>
                                             </view>
                                         </subviews>
@@ -294,19 +295,19 @@
                                         </connections>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2회" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIq-aM-1AQ" userLabel="Inning Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="540" y="15" width="25" height="21"/>
+                                        <rect key="frame" x="315" y="15" width="25" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="초" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eJB-sg-M1p" userLabel="Half Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="570" y="15" width="15" height="21"/>
+                                        <rect key="frame" x="345" y="15" width="15" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="공격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ky5-km-ZdB" userLabel="Offense Defense Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="555.5" y="40" width="29.5" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ky5-km-ZdB" userLabel="Offense Defense Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="330.5" y="40" width="29.5" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -327,24 +328,30 @@
                                     <constraint firstAttribute="trailing" secondItem="Ky5-km-ZdB" secondAttribute="trailing" constant="15" id="Zqx-sc-Zk9"/>
                                     <constraint firstItem="LIq-aM-1AQ" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="top" id="oGL-iy-f55"/>
                                 </constraints>
+                                <connections>
+                                    <outlet property="halfLabel" destination="eJB-sg-M1p" id="LYX-8Z-Zp4"/>
+                                    <outlet property="inningLabel" destination="LIq-aM-1AQ" id="sPI-PP-gsk"/>
+                                    <outlet property="offenseOrDefense" destination="Ky5-km-ZdB" id="Ls4-ip-vBs"/>
+                                    <outlet property="sbosView" destination="o0Q-Hm-fNb" id="VtW-lZ-xs6"/>
+                                </connections>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
-                                <rect key="frame" x="0.0" y="313.5" width="600" height="115.5"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
+                                <rect key="frame" x="0.0" y="313.5" width="375" height="115.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
                                 </constraints>
                                 <sections/>
                             </tableView>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">
-                                <rect key="frame" x="0.0" y="429" width="600" height="3"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">
+                                <rect key="frame" x="0.0" y="429" width="375" height="3"/>
                                 <color key="backgroundColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="3" id="0fd-SS-f7a"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb" userLabel="Batter Info Table">
-                                <rect key="frame" x="0.0" y="432" width="600" height="186"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb" userLabel="Batter Info Table">
+                                <rect key="frame" x="0.0" y="432" width="375" height="186"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             </tableView>
                         </subviews>
@@ -387,7 +394,6 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" navigationBarHidden="YES" id="NiE-Ip-oQf" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="0E8-nZ-XtR">
-                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -264,13 +264,20 @@
                                     <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Batter Info Label">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Batter Info Table">
                                 <rect key="frame" x="0.0" y="313.5" width="375" height="115.5"/>
                                 <color key="backgroundColor" red="0.39637178020000002" green="0.79289596709999999" blue="0.78547235550000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
                                 </constraints>
                             </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">
+                                <rect key="frame" x="0.0" y="429" width="375" height="3"/>
+                                <color key="backgroundColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="3" id="0fd-SS-f7a"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
@@ -282,9 +289,12 @@
                             <constraint firstItem="0pg-RC-Isx" firstAttribute="top" secondItem="2fF-x6-cX0" secondAttribute="bottom" id="U8i-TQ-eSu"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Wwo-Lt-iZX"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dDA-x6-gdQ"/>
+                            <constraint firstItem="KrS-IH-5bc" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dWx-ME-TJ4"/>
                             <constraint firstItem="2fF-x6-cX0" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="ghc-Z8-Mx1"/>
                             <constraint firstItem="0pg-RC-Isx" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="k9m-aJ-Bhk"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="top" secondItem="aSi-rk-FUG" secondAttribute="bottom" id="n8k-hw-9jE"/>
+                            <constraint firstItem="KrS-IH-5bc" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="sWO-a1-f0K"/>
+                            <constraint firstItem="KrS-IH-5bc" firstAttribute="top" secondItem="0pg-RC-Isx" secondAttribute="bottom" id="tpv-Xc-d09"/>
                             <constraint firstItem="0pg-RC-Isx" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="xqm-ey-C4G"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -260,11 +260,37 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View">
                                 <rect key="frame" x="0.0" y="63.5" width="375" height="250"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" userLabel="Board Count View">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" userLabel="Board Counts View">
                                         <rect key="frame" x="15" y="15" width="97.5" height="75"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nVw-tg-xeD" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="0.0" width="97.5" height="25"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3ii-ab-PXe" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="25" width="97.5" height="24.5"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ztM-E3-dzb" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="49.5" width="97.5" height="25"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            </view>
+                                        </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="1.3:1" id="tr8-00-cMU"/>
+                                            <constraint firstItem="ztM-E3-dzb" firstAttribute="height" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="0.33" id="4PT-z9-ViW"/>
+                                            <constraint firstItem="3ii-ab-PXe" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="bottom" id="4g3-Bm-XSx"/>
+                                            <constraint firstItem="ztM-E3-dzb" firstAttribute="top" secondItem="3ii-ab-PXe" secondAttribute="bottom" id="AIq-vm-R5R"/>
+                                            <constraint firstItem="ztM-E3-dzb" firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="width" id="KK0-y3-083"/>
+                                            <constraint firstItem="ztM-E3-dzb" firstAttribute="leading" secondItem="o0Q-Hm-fNb" secondAttribute="leading" id="Lse-O2-TLH"/>
+                                            <constraint firstItem="nVw-tg-xeD" firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="width" id="OBk-J8-dEm"/>
+                                            <constraint firstItem="3ii-ab-PXe" firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="width" id="SCb-be-Glj"/>
+                                            <constraint firstItem="3ii-ab-PXe" firstAttribute="height" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="0.33" id="XhB-27-lXB"/>
+                                            <constraint firstItem="nVw-tg-xeD" firstAttribute="height" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="0.33" id="aXk-BY-WJi"/>
+                                            <constraint firstItem="3ii-ab-PXe" firstAttribute="leading" secondItem="o0Q-Hm-fNb" secondAttribute="leading" id="g5z-9z-TxR"/>
+                                            <constraint firstItem="nVw-tg-xeD" firstAttribute="leading" secondItem="o0Q-Hm-fNb" secondAttribute="leading" id="osx-4z-XBc"/>
+                                            <constraint firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="13:10" id="tr8-00-cMU"/>
+                                            <constraint firstItem="nVw-tg-xeD" firstAttribute="top" secondItem="o0Q-Hm-fNb" secondAttribute="top" id="xmb-0m-JE0"/>
                                         </constraints>
                                     </view>
                                 </subviews>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -391,6 +391,11 @@
                                                 <constraint firstItem="bxI-X5-HdE" firstAttribute="centerY" secondItem="VIh-gv-AK0" secondAttribute="centerY" id="sAd-Ka-beZ"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="playerName" destination="u1f-q0-ZYx" id="6tJ-IJ-eJA"/>
+                                            <outlet property="playerRole" destination="bxI-X5-HdE" id="kGY-Bh-Kff"/>
+                                            <outlet property="valueLabel" destination="FMb-tJ-vHJ" id="ABr-cg-0le"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                                 <sections/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -278,9 +278,8 @@
                                     <constraint firstAttribute="height" constant="3" id="0fd-SS-f7a"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb">
-                                <rect key="frame" x="62" y="446" width="240" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb" userLabel="Batter Info Table">
+                                <rect key="frame" x="0.0" y="432" width="375" height="186"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             </tableView>
                         </subviews>
@@ -289,6 +288,8 @@
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="top" secondItem="Hvq-eV-AVL" secondAttribute="top" id="0mA-Nc-q4r"/>
                             <constraint firstItem="2fF-x6-cX0" firstAttribute="top" secondItem="jpd-qi-a5W" secondAttribute="bottom" id="687-0S-JeW"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Bc8-Eg-gBM"/>
+                            <constraint firstItem="tE3-mc-Ysb" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="EEq-85-eGO"/>
+                            <constraint firstItem="tE3-mc-Ysb" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="QoV-if-MQ7"/>
                             <constraint firstItem="2fF-x6-cX0" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="T70-vn-72c"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="Tre-pF-HCn"/>
                             <constraint firstItem="0pg-RC-Isx" firstAttribute="top" secondItem="2fF-x6-cX0" secondAttribute="bottom" id="U8i-TQ-eSu"/>
@@ -296,10 +297,12 @@
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dDA-x6-gdQ"/>
                             <constraint firstItem="KrS-IH-5bc" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dWx-ME-TJ4"/>
                             <constraint firstItem="2fF-x6-cX0" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="ghc-Z8-Mx1"/>
+                            <constraint firstItem="tE3-mc-Ysb" firstAttribute="top" secondItem="KrS-IH-5bc" secondAttribute="bottom" id="ihx-t6-jxM"/>
                             <constraint firstItem="0pg-RC-Isx" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="k9m-aJ-Bhk"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="top" secondItem="aSi-rk-FUG" secondAttribute="bottom" id="n8k-hw-9jE"/>
                             <constraint firstItem="KrS-IH-5bc" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="sWO-a1-f0K"/>
                             <constraint firstItem="KrS-IH-5bc" firstAttribute="top" secondItem="0pg-RC-Isx" secondAttribute="bottom" id="tpv-Xc-d09"/>
+                            <constraint firstItem="Hvq-eV-AVL" firstAttribute="bottom" secondItem="tE3-mc-Ysb" secondAttribute="bottom" id="xgV-B8-PQs"/>
                             <constraint firstItem="0pg-RC-Isx" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="xqm-ey-C4G"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="NiE-Ip-oQf">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -12,7 +11,7 @@
             <objects>
                 <viewController storyboardIdentifier="GameRoomViewController" id="xl2-2U-nfi" customClass="GameRoomViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mJ7-rS-pgE">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <viewLayoutGuide key="safeArea" id="Wny-TU-azI"/>
@@ -27,17 +26,17 @@
             <objects>
                 <viewController id="4qG-2e-g0p" customClass="MainViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cOi-Ug-8eN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="batter" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-VR-5Nb">
-                                <rect key="frame" x="32" y="44.5" width="311" height="311"/>
+                                <rect key="frame" x="51" y="-69" width="498" height="498"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="zK2-VR-5Nb" secondAttribute="height" multiplier="1:1" id="3iZ-3E-7dH"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yIB-ep-Rll">
-                                <rect key="frame" x="30" y="348.5" width="315" height="39.5"/>
+                                <rect key="frame" x="142.5" y="422" width="315" height="39.5"/>
                                 <attributedString key="attributedText">
                                     <fragment content="KBO Baseball game">
                                         <attributes>
@@ -50,7 +49,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q5p-zu-nMg" customClass="BorderedButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="15" y="418" width="345" height="40"/>
+                                <rect key="frame" x="15" y="491.5" width="570" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="bJR-rf-Q6X"/>
                                 </constraints>
@@ -62,7 +61,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IjI-2N-etU" customClass="BorderedButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="15" y="473" width="345" height="40"/>
+                                <rect key="frame" x="15" y="546.5" width="570" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="zzB-Tk-QKR"/>
                                 </constraints>
@@ -98,22 +97,22 @@
             <objects>
                 <viewController storyboardIdentifier="LoginViewController" id="QXQ-4t-51P" customClass="LoginViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Nyt-ff-rlX">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="아이디 또는 이메일" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="wVr-Uk-bIh" userLabel="IDTextField">
-                                <rect key="frame" x="15" y="233" width="345" height="34"/>
+                                <rect key="frame" x="15" y="208" width="570" height="34"/>
                                 <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="비밀번호" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3IV-7t-fDh" userLabel="PasswordTextField">
-                                <rect key="frame" x="15" y="282" width="345" height="34"/>
+                                <rect key="frame" x="15" y="257" width="570" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xUP-YI-cXb" customClass="BorderedButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="15" y="331" width="345" height="40"/>
+                                <rect key="frame" x="15" y="306" width="570" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="ZiL-lF-Vkn"/>
                                 </constraints>
@@ -122,27 +121,27 @@
                                 <state key="normal" title="로그인"/>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2bj-KN-3QL">
-                                <rect key="frame" x="178.5" y="386" width="18" height="23"/>
+                                <rect key="frame" x="291" y="361" width="18" height="23"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <color key="textColor" cocoaTouchSystemColor="scrollViewTexturedBackgroundColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a0j-wY-PSj">
-                                <rect key="frame" x="15" y="397" width="157.5" height="1"/>
+                                <rect key="frame" x="15" y="372" width="252" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="l0X-KA-495"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8s-Zd-lZ4">
-                                <rect key="frame" x="202.5" y="397" width="157.5" height="1"/>
+                                <rect key="frame" x="333" y="372" width="252" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="zQS-fI-m2M"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xYD-5F-1kT" customClass="OauthLoginButton" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="108.5" y="424" width="158.5" height="22"/>
+                                <rect key="frame" x="221" y="399" width="158.5" height="22"/>
                                 <state key="normal" title="Github으로 로그인" image="github">
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
@@ -151,7 +150,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wys-LL-uxP">
-                                <rect key="frame" x="30" y="153.5" width="315" height="39.5"/>
+                                <rect key="frame" x="142.5" y="128.5" width="315" height="39.5"/>
                                 <attributedString key="attributedText">
                                     <fragment content="KBO Baseball game">
                                         <attributes>
@@ -200,17 +199,17 @@
             <objects>
                 <viewController id="qaG-7m-vvT" customClass="ScoresViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aJF-G8-Naq">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mBQ-yj-4gl" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="35.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="mBQ-yj-4gl" secondAttribute="height" multiplier="17:1" id="lJz-Oj-Lis"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hYS-x3-cZA" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="22" width="375" height="41.5"/>
+                                <rect key="frame" x="0.0" y="35.5" width="600" height="66.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="hYS-x3-cZA" secondAttribute="height" multiplier="9:1" id="yLB-Fz-PLB"/>
@@ -242,41 +241,37 @@
             <objects>
                 <viewController id="cSG-l2-sFt" customClass="PlayViewController" customModule="BaseballGame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kMd-Vk-jkA">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aSi-rk-FUG" customClass="TitleView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="22"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="35.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="aSi-rk-FUG" secondAttribute="height" multiplier="17:1" id="yiO-X5-Xao"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jpd-qi-a5W" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="22" width="375" height="41.5"/>
+                                <rect key="frame" x="0.0" y="35.5" width="600" height="66.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="jpd-qi-a5W" secondAttribute="height" multiplier="9:1" id="GjB-B1-QwW"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View">
-                                <rect key="frame" x="0.0" y="63.5" width="375" height="250"/>
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View">
+                                <rect key="frame" x="0.0" y="63.5" width="600" height="250"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" userLabel="Board Counts View">
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" userLabel="Board Counts View" customClass="SBOsView" customModule="BaseballGame" customModuleProvider="target">
                                         <rect key="frame" x="15" y="15" width="97.5" height="75"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nVw-tg-xeD" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nVw-tg-xeD" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="97.5" height="25"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3ii-ab-PXe" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3ii-ab-PXe" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="25" width="97.5" height="24.5"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ztM-E3-dzb" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ztM-E3-dzb" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="49.5" width="97.5" height="25"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                             </view>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstItem="ztM-E3-dzb" firstAttribute="height" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="0.33" id="4PT-z9-ViW"/>
                                             <constraint firstItem="3ii-ab-PXe" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="bottom" id="4g3-Bm-XSx"/>
@@ -292,21 +287,26 @@
                                             <constraint firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="13:10" id="tr8-00-cMU"/>
                                             <constraint firstItem="nVw-tg-xeD" firstAttribute="top" secondItem="o0Q-Hm-fNb" secondAttribute="top" id="xmb-0m-JE0"/>
                                         </constraints>
+                                        <connections>
+                                            <outlet property="ballView" destination="3ii-ab-PXe" id="dgM-fy-Wkz"/>
+                                            <outlet property="outView" destination="ztM-E3-dzb" id="Ttp-q3-wOD"/>
+                                            <outlet property="strikeView" destination="nVw-tg-xeD" id="y6H-no-rbC"/>
+                                        </connections>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2회" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIq-aM-1AQ" userLabel="Inning Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="315" y="15" width="25" height="21"/>
+                                        <rect key="frame" x="540" y="15" width="25" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="초" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eJB-sg-M1p" userLabel="Half Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="345" y="15" width="15" height="21"/>
+                                        <rect key="frame" x="570" y="15" width="15" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ky5-km-ZdB" userLabel="Offense Defense Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="330.5" y="40" width="29.5" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="공격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ky5-km-ZdB" userLabel="Offense Defense Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="555.5" y="40" width="29.5" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -328,23 +328,23 @@
                                     <constraint firstItem="LIq-aM-1AQ" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="top" id="oGL-iy-f55"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
-                                <rect key="frame" x="0.0" y="313.5" width="375" height="115.5"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
+                                <rect key="frame" x="0.0" y="313.5" width="600" height="115.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
                                 </constraints>
                                 <sections/>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">
-                                <rect key="frame" x="0.0" y="429" width="375" height="3"/>
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">
+                                <rect key="frame" x="0.0" y="429" width="600" height="3"/>
                                 <color key="backgroundColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="3" id="0fd-SS-f7a"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb" userLabel="Batter Info Table">
-                                <rect key="frame" x="0.0" y="432" width="375" height="186"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb" userLabel="Batter Info Table">
+                                <rect key="frame" x="0.0" y="432" width="600" height="186"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             </tableView>
                         </subviews>
@@ -387,6 +387,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" navigationBarHidden="YES" id="NiE-Ip-oQf" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="0E8-nZ-XtR">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -293,13 +293,39 @@
                                             <constraint firstItem="nVw-tg-xeD" firstAttribute="top" secondItem="o0Q-Hm-fNb" secondAttribute="top" id="xmb-0m-JE0"/>
                                         </constraints>
                                     </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2회" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIq-aM-1AQ" userLabel="Inning Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="315" y="15" width="25" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="초" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eJB-sg-M1p" userLabel="Half Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="345" y="15" width="15" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ky5-km-ZdB" userLabel="Offense Defense Label" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="330.5" y="40" width="29.5" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstItem="LIq-aM-1AQ" firstAttribute="trailing" secondItem="eJB-sg-M1p" secondAttribute="leading" constant="-5" id="5iO-Wh-rLZ"/>
+                                    <constraint firstItem="LIq-aM-1AQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="o0Q-Hm-fNb" secondAttribute="trailing" constant="8" symbolic="YES" id="6Vp-Fe-CWY"/>
+                                    <constraint firstItem="eJB-sg-M1p" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="top" id="8p6-4j-G0n"/>
                                     <constraint firstItem="o0Q-Hm-fNb" firstAttribute="height" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="0.3" id="9MH-u1-QEu"/>
                                     <constraint firstItem="o0Q-Hm-fNb" firstAttribute="top" secondItem="2fF-x6-cX0" secondAttribute="top" constant="15" id="GSn-B5-PkC"/>
                                     <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
                                     <constraint firstItem="o0Q-Hm-fNb" firstAttribute="leading" secondItem="2fF-x6-cX0" secondAttribute="leading" constant="15" id="M6n-Mo-mHz"/>
+                                    <constraint firstItem="Ky5-km-ZdB" firstAttribute="top" secondItem="3ii-ab-PXe" secondAttribute="top" id="Vis-HL-INX"/>
+                                    <constraint firstAttribute="trailing" secondItem="eJB-sg-M1p" secondAttribute="trailing" constant="15" id="Xyw-VW-M7v"/>
+                                    <constraint firstItem="Ky5-km-ZdB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="o0Q-Hm-fNb" secondAttribute="trailing" constant="8" symbolic="YES" id="Y8P-42-n9j"/>
+                                    <constraint firstAttribute="trailing" secondItem="Ky5-km-ZdB" secondAttribute="trailing" constant="15" id="Zqx-sc-Zk9"/>
+                                    <constraint firstItem="LIq-aM-1AQ" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="top" id="oGL-iy-f55"/>
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -341,6 +341,44 @@
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
                                 </constraints>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="CurrentPlayerCell" id="zzQ-5N-HX5" customClass="CurrentPlayerCell" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zzQ-5N-HX5" id="VIh-gv-AK0">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="투수" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxI-X5-HdE" customClass="PlayTableLabel" customModule="BaseballGame" customModuleProvider="target">
+                                                    <rect key="frame" x="21" y="10.5" width="33" height="23"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최동원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1f-q0-ZYx" customClass="PlayTableLabel" customModule="BaseballGame" customModuleProvider="target">
+                                                    <rect key="frame" x="71.5" y="11.5" width="45" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#39" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FMb-tJ-vHJ" customClass="PlayTableLabel" customModule="BaseballGame" customModuleProvider="target">
+                                                    <rect key="frame" x="209" y="11.5" width="32" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="FMb-tJ-vHJ" firstAttribute="centerX" secondItem="VIh-gv-AK0" secondAttribute="centerX" multiplier="1.2" id="F42-Ai-XCg"/>
+                                                <constraint firstItem="FMb-tJ-vHJ" firstAttribute="centerY" secondItem="VIh-gv-AK0" secondAttribute="centerY" id="NBA-fK-R7x"/>
+                                                <constraint firstItem="u1f-q0-ZYx" firstAttribute="centerX" secondItem="VIh-gv-AK0" secondAttribute="centerX" multiplier="0.5" id="QeY-3U-7WI"/>
+                                                <constraint firstItem="bxI-X5-HdE" firstAttribute="centerX" secondItem="VIh-gv-AK0" secondAttribute="centerX" multiplier="0.2" id="QfJ-dD-RcM"/>
+                                                <constraint firstItem="u1f-q0-ZYx" firstAttribute="centerY" secondItem="VIh-gv-AK0" secondAttribute="centerY" id="iQn-aw-cUJ"/>
+                                                <constraint firstItem="bxI-X5-HdE" firstAttribute="centerY" secondItem="VIh-gv-AK0" secondAttribute="centerY" id="sAd-Ka-beZ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
                                 <sections/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -259,9 +259,21 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-x6-cX0" userLabel="Board View">
                                 <rect key="frame" x="0.0" y="63.5" width="375" height="250"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" userLabel="Board Count View">
+                                        <rect key="frame" x="15" y="15" width="97.5" height="75"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="1.3:1" id="tr8-00-cMU"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
                                 <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstItem="o0Q-Hm-fNb" firstAttribute="height" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="0.3" id="9MH-u1-QEu"/>
+                                    <constraint firstItem="o0Q-Hm-fNb" firstAttribute="top" secondItem="2fF-x6-cX0" secondAttribute="top" constant="15" id="GSn-B5-PkC"/>
                                     <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
+                                    <constraint firstItem="o0Q-Hm-fNb" firstAttribute="leading" secondItem="2fF-x6-cX0" secondAttribute="leading" constant="15" id="M6n-Mo-mHz"/>
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
@@ -270,6 +282,7 @@
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
                                 </constraints>
+                                <sections/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KrS-IH-5bc" userLabel="Line">
                                 <rect key="frame" x="0.0" y="429" width="375" height="3"/>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -312,6 +312,17 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aFf-Ac-xAD" customClass="PitchButton" customModule="BaseballGame" customModuleProvider="target">
+                                        <rect key="frame" x="131.5" y="108.5" width="112.5" height="27.5"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="aFf-Ac-xAD" secondAttribute="height" multiplier="105:26" id="YxB-lc-Efz"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                        <state key="normal" title="PITCH">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -322,9 +333,12 @@
                                     <constraint firstItem="o0Q-Hm-fNb" firstAttribute="top" secondItem="2fF-x6-cX0" secondAttribute="top" constant="15" id="GSn-B5-PkC"/>
                                     <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
                                     <constraint firstItem="o0Q-Hm-fNb" firstAttribute="leading" secondItem="2fF-x6-cX0" secondAttribute="leading" constant="15" id="M6n-Mo-mHz"/>
+                                    <constraint firstItem="aFf-Ac-xAD" firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="width" multiplier="0.3" id="MEO-RP-5IT"/>
                                     <constraint firstItem="Ky5-km-ZdB" firstAttribute="top" secondItem="3ii-ab-PXe" secondAttribute="top" id="Vis-HL-INX"/>
+                                    <constraint firstItem="aFf-Ac-xAD" firstAttribute="centerX" secondItem="2fF-x6-cX0" secondAttribute="centerX" id="Xn8-RC-Lce"/>
                                     <constraint firstAttribute="trailing" secondItem="eJB-sg-M1p" secondAttribute="trailing" constant="15" id="Xyw-VW-M7v"/>
                                     <constraint firstItem="Ky5-km-ZdB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="o0Q-Hm-fNb" secondAttribute="trailing" constant="8" symbolic="YES" id="Y8P-42-n9j"/>
+                                    <constraint firstItem="aFf-Ac-xAD" firstAttribute="centerY" secondItem="2fF-x6-cX0" secondAttribute="centerY" constant="-3" id="ZOz-LI-2Xf"/>
                                     <constraint firstAttribute="trailing" secondItem="Ky5-km-ZdB" secondAttribute="trailing" constant="15" id="Zqx-sc-Zk9"/>
                                     <constraint firstItem="LIq-aM-1AQ" firstAttribute="top" secondItem="nVw-tg-xeD" secondAttribute="top" id="oGL-iy-f55"/>
                                 </constraints>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -261,16 +261,16 @@
                                 <rect key="frame" x="0.0" y="63.5" width="375" height="250"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0Q-Hm-fNb" customClass="SBOsView" customModule="BaseballGame" customModuleProvider="target">
-                                        <rect key="frame" x="15" y="15" width="97.5" height="75"/>
+                                        <rect key="frame" x="15" y="15" width="105" height="75"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nVw-tg-xeD" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="97.5" height="25"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="105" height="25"/>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3ii-ab-PXe" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="25" width="97.5" height="24.5"/>
+                                                <rect key="frame" x="0.0" y="25" width="105" height="24.5"/>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ztM-E3-dzb" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="49.5" width="97.5" height="25"/>
+                                                <rect key="frame" x="0.0" y="49.5" width="105" height="25"/>
                                             </view>
                                         </subviews>
                                         <constraints>
@@ -285,7 +285,7 @@
                                             <constraint firstItem="nVw-tg-xeD" firstAttribute="height" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="0.33" id="aXk-BY-WJi"/>
                                             <constraint firstItem="3ii-ab-PXe" firstAttribute="leading" secondItem="o0Q-Hm-fNb" secondAttribute="leading" id="g5z-9z-TxR"/>
                                             <constraint firstItem="nVw-tg-xeD" firstAttribute="leading" secondItem="o0Q-Hm-fNb" secondAttribute="leading" id="osx-4z-XBc"/>
-                                            <constraint firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="13:10" id="tr8-00-cMU"/>
+                                            <constraint firstAttribute="width" secondItem="o0Q-Hm-fNb" secondAttribute="height" multiplier="14:10" id="tr8-00-cMU"/>
                                             <constraint firstItem="nVw-tg-xeD" firstAttribute="top" secondItem="o0Q-Hm-fNb" secondAttribute="top" id="xmb-0m-JE0"/>
                                         </constraints>
                                         <connections>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -264,6 +264,13 @@
                                     <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
                                 </constraints>
                             </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Batter Info Label">
+                                <rect key="frame" x="0.0" y="313.5" width="375" height="115.5"/>
+                                <color key="backgroundColor" red="0.39637178020000002" green="0.79289596709999999" blue="0.78547235550000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
+                                </constraints>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
@@ -272,10 +279,13 @@
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Bc8-Eg-gBM"/>
                             <constraint firstItem="2fF-x6-cX0" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="T70-vn-72c"/>
                             <constraint firstItem="aSi-rk-FUG" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="Tre-pF-HCn"/>
+                            <constraint firstItem="0pg-RC-Isx" firstAttribute="top" secondItem="2fF-x6-cX0" secondAttribute="bottom" id="U8i-TQ-eSu"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="Wwo-Lt-iZX"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="dDA-x6-gdQ"/>
                             <constraint firstItem="2fF-x6-cX0" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="ghc-Z8-Mx1"/>
+                            <constraint firstItem="0pg-RC-Isx" firstAttribute="leading" secondItem="Hvq-eV-AVL" secondAttribute="leading" id="k9m-aJ-Bhk"/>
                             <constraint firstItem="jpd-qi-a5W" firstAttribute="top" secondItem="aSi-rk-FUG" secondAttribute="bottom" id="n8k-hw-9jE"/>
+                            <constraint firstItem="0pg-RC-Isx" firstAttribute="width" secondItem="Hvq-eV-AVL" secondAttribute="width" id="xqm-ey-C4G"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Hvq-eV-AVL"/>
                     </view>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -264,7 +264,7 @@
                                     <constraint firstAttribute="width" secondItem="2fF-x6-cX0" secondAttribute="height" multiplier="3:2" id="JYM-ZA-mim"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Batter Info Table">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
                                 <rect key="frame" x="0.0" y="313.5" width="375" height="115.5"/>
                                 <color key="backgroundColor" red="0.39637178020000002" green="0.79289596709999999" blue="0.78547235550000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
@@ -278,6 +278,11 @@
                                     <constraint firstAttribute="height" constant="3" id="0fd-SS-f7a"/>
                                 </constraints>
                             </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-mc-Ysb">
+                                <rect key="frame" x="62" y="446" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -266,7 +266,7 @@
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0pg-RC-Isx" userLabel="Current Player Table">
                                 <rect key="frame" x="0.0" y="313.5" width="375" height="115.5"/>
-                                <color key="backgroundColor" red="0.39637178020000002" green="0.79289596709999999" blue="0.78547235550000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0pg-RC-Isx" secondAttribute="height" multiplier="140:43" id="qgq-QT-NzK"/>
                                 </constraints>

--- a/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
+++ b/iOS/BaseballGame/BaseballGame/Base.lproj/Main.storyboard
@@ -411,13 +411,49 @@
                                 <rect key="frame" x="0.0" y="432" width="375" height="186"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="BatterInfoCell" id="xPN-eW-c5v">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="BatterInfoCell" id="xPN-eW-c5v" customClass="BatterInfoCell" customModule="BaseballGame" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xPN-eW-c5v" id="604-6f-aKH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ul6-ch-Jat" customClass="OrderLabel" customModule="BaseballGame" customModuleProvider="target">
+                                                    <rect key="frame" x="26.5" y="11" width="22" height="21.5"/>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="ul6-ch-Jat" secondAttribute="height" multiplier="1:1" id="yvz-Kp-hD9"/>
+                                                    </constraints>
+                                                </view>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="스트라이크" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BxA-jK-v9O">
+                                                    <rect key="frame" x="73.5" y="11.5" width="74" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1-2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cGz-UJ-Qdb">
+                                                    <rect key="frame" x="332" y="10.5" width="28" height="23"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="BxA-jK-v9O" firstAttribute="leading" secondItem="ul6-ch-Jat" secondAttribute="trailing" constant="25" id="EbL-eL-Xc0"/>
+                                                <constraint firstItem="ul6-ch-Jat" firstAttribute="height" secondItem="604-6f-aKH" secondAttribute="height" multiplier="0.5" id="Mhp-kp-ruG"/>
+                                                <constraint firstItem="BxA-jK-v9O" firstAttribute="centerY" secondItem="604-6f-aKH" secondAttribute="centerY" id="SQp-Fk-0sV"/>
+                                                <constraint firstItem="ul6-ch-Jat" firstAttribute="centerX" secondItem="604-6f-aKH" secondAttribute="centerX" multiplier="0.2" id="WWZ-eb-7jn"/>
+                                                <constraint firstItem="cGz-UJ-Qdb" firstAttribute="centerY" secondItem="604-6f-aKH" secondAttribute="centerY" id="gDo-yK-qAP"/>
+                                                <constraint firstItem="ul6-ch-Jat" firstAttribute="centerY" secondItem="604-6f-aKH" secondAttribute="centerY" id="pUZ-gy-SmX"/>
+                                                <constraint firstAttribute="trailing" secondItem="cGz-UJ-Qdb" secondAttribute="trailing" constant="15" id="wIM-7t-AuU"/>
+                                                <constraint firstItem="cGz-UJ-Qdb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="BxA-jK-v9O" secondAttribute="trailing" constant="8" symbolic="YES" id="wkX-ah-hKy"/>
+                                            </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="countLabel" destination="cGz-UJ-Qdb" id="24T-E4-WRU"/>
+                                            <outlet property="orderLabel" destination="ul6-ch-Jat" id="ttY-tf-KXU"/>
+                                            <outlet property="sboLabel" destination="BxA-jK-v9O" id="fVy-1e-3gt"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/BatterInfoCell.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/BatterInfoCell.swift
@@ -9,6 +9,10 @@
 import UIKit
 
 final class BatterInfoCell: UITableViewCell, IdentifiableView {
+    @IBOutlet weak var orderLabel: OrderLabel!
+    @IBOutlet weak var sboLabel: UILabel!
+    @IBOutlet weak var countLabel: UILabel!  
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
     }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/BatterInfoCell.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/BatterInfoCell.swift
@@ -1,0 +1,27 @@
+//
+//  BatterInfoCell.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class BatterInfoCell: UITableViewCell, IdentifiableView {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/BoardLabel.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/BoardLabel.swift
@@ -1,0 +1,27 @@
+//
+//  BoardLabel.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class BoardLabel: UILabel {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        translatesAutoresizingMaskIntoConstraints = false 
+        configureText()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureText()
+    }
+    
+    private func configureText() {
+        textColor = .black
+        font = UIFont.boldSystemFont(ofSize: 20)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/BoardView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/BoardView.swift
@@ -1,0 +1,24 @@
+//
+//  BoardView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class BoardView: UIView {
+    @IBOutlet weak var sbosView: SBOsView!
+    @IBOutlet weak var inningLabel: BoardLabel!
+    @IBOutlet weak var halfLabel: BoardLabel!
+    @IBOutlet weak var offenseOrDefense: BoardLabel!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.swift
@@ -10,6 +10,9 @@ import UIKit
 
 @IBDesignable
 final class CountView: UIView, WithXib {
+    @IBOutlet weak var sboLabel: BoardLabel!
+    @IBOutlet weak var countStack: UIStackView!
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         insertXibView()

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.swift
@@ -1,0 +1,22 @@
+//
+//  CountView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+final class CountView: UIView, WithXib {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        insertXibView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        insertXibView()
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.swift
@@ -1,0 +1,37 @@
+//
+//  CountView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class CountView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    private func configure() {
+        widthAnchor.constraint(equalTo: heightAnchor).isActive = true
+        hide()
+    }
+    
+    func hide() {
+        backgroundColor = .none
+        layer.borderWidth = 0
+    }
+    
+    func show(color: UIColor) {
+        backgroundColor = color
+        layer.borderWidth = 0.5
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CountView" customModule="BaseballGame" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="156" height="24"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="S" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v8G-s8-aLx" customClass="BoardLabel" customModule="BaseballGame" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="13" height="24"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MTF-oF-Bwy">
+                    <rect key="frame" x="21" y="0.0" width="135" height="24"/>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="v8G-s8-aLx" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="EmO-CP-h6b"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="v8G-s8-aLx" secondAttribute="bottom" id="fsG-1r-jbD"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="top" secondItem="MTF-oF-Bwy" secondAttribute="top" id="hj7-cs-AJj"/>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="height" secondItem="v8G-s8-aLx" secondAttribute="height" id="hu0-1r-Cad"/>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="leading" secondItem="v8G-s8-aLx" secondAttribute="trailing" constant="8" id="k8g-xn-Jkq"/>
+                <constraint firstItem="v8G-s8-aLx" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="qdT-9A-AK0"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="MTF-oF-Bwy" secondAttribute="bottom" id="qy6-Xw-i4g"/>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="v4r-ca-hN8"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="137.59999999999999" y="140.32983508245877"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CountView.xib
@@ -7,7 +7,12 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CountView" customModule="BaseballGame" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+            <connections>
+                <outlet property="countStack" destination="MTF-oF-Bwy" id="r6W-1B-Gza"/>
+                <outlet property="sboLabel" destination="v8G-s8-aLx" id="rS8-sN-kCv"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="156" height="24"/>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CurrentPlayerCell.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CurrentPlayerCell.swift
@@ -9,6 +9,10 @@
 import UIKit
 
 final class CurrentPlayerCell: UITableViewCell, IdentifiableView {
+    @IBOutlet weak var playerRole: PlayTableLabel!
+    @IBOutlet weak var playerName: PlayTableLabel!
+    @IBOutlet weak var valueLabel: PlayTableLabel!
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
     }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/CurrentPlayerCell.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/CurrentPlayerCell.swift
@@ -1,0 +1,27 @@
+//
+//  CurrentPlayerCell.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class CurrentPlayerCell: UITableViewCell, IdentifiableView {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/OrderLabel.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/OrderLabel.swift
@@ -1,0 +1,31 @@
+//
+//  OrderView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class OrderLabel: UILabel {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    private func configure() {
+        layer.cornerRadius = bounds.width
+        configureText()
+    }
+    
+    private func configureText() {
+        textColor = .white
+        text = "1"
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/OrderView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/OrderView.swift
@@ -1,0 +1,31 @@
+//
+//  OrderView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class OrderLabel: UILabel {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    private func configure() {
+        layer.cornerRadius = bounds.width
+        configureText()
+    }
+    
+    private func configureText() {
+        textColor = .white
+        text = "1"
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/PitchButton.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/PitchButton.swift
@@ -1,0 +1,25 @@
+//
+//  PitchButton.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class PitchButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    private func configure() {
+        layer.cornerRadius = 5
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/PlayTableLabel.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/PlayTableLabel.swift
@@ -1,0 +1,25 @@
+//
+//  CurrentPlayerLabel.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class PlayTableLabel: UILabel {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureText()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureText()
+    }
+    
+    private func configureText() {
+        font = UIFont.systemFont(ofSize: 19, weight: .medium)
+    }
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.swift
@@ -12,14 +12,35 @@ import UIKit
 final class SBOView: UIView, WithXib {
     @IBOutlet weak var sboLabel: BoardLabel!
     @IBOutlet weak var countStack: UIStackView!
+    private var countViews: [CountView]!
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         insertXibView()
+        insertCountViews()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         insertXibView()
+        insertCountViews()
+    }
+    
+    private func insertCountViews() {
+        countViews = initCountViews()
+        countViews.forEach {
+            countStack.addArrangedSubview($0)
+            $0.layer.cornerRadius = countStack.bounds.height / 2
+        }
+    }
+    
+    private func initCountViews() -> [CountView] {
+        var views = [CountView]()
+        let totalCount = 4
+        for _ in 0 ..< totalCount {
+            let view = CountView()
+            views.append(view)
+        }
+        return views
     }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @IBDesignable
-final class CountView: UIView, WithXib {
+final class SBOView: UIView, WithXib {
     @IBOutlet weak var sboLabel: BoardLabel!
     @IBOutlet weak var countStack: UIStackView!
     

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.xib
@@ -7,7 +7,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CountView" customModule="BaseballGame" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SBOView" customModule="BaseballGame" customModuleProvider="target">
             <connections>
                 <outlet property="countStack" destination="MTF-oF-Bwy" id="r6W-1B-Gza"/>
                 <outlet property="sboLabel" destination="v8G-s8-aLx" id="rS8-sN-kCv"/>
@@ -28,7 +28,6 @@
                     <rect key="frame" x="21" y="0.0" width="135" height="24"/>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
                 <constraint firstItem="v8G-s8-aLx" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="EmO-CP-h6b"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="v8G-s8-aLx" secondAttribute="bottom" id="fsG-1r-jbD"/>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOView.xib
@@ -24,19 +24,18 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MTF-oF-Bwy">
-                    <rect key="frame" x="21" y="0.0" width="135" height="24"/>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="MTF-oF-Bwy">
+                    <rect key="frame" x="31" y="2.5" width="125" height="19"/>
                 </stackView>
             </subviews>
             <constraints>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="height" secondItem="vUN-kp-3ea" secondAttribute="height" multiplier="0.78" id="Bh0-tS-HIJ"/>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="DmM-0k-ux3"/>
                 <constraint firstItem="v8G-s8-aLx" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="EmO-CP-h6b"/>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" multiplier="1.2" id="Ptl-Ki-6VC"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="v8G-s8-aLx" secondAttribute="bottom" id="fsG-1r-jbD"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="top" secondItem="MTF-oF-Bwy" secondAttribute="top" id="hj7-cs-AJj"/>
-                <constraint firstItem="MTF-oF-Bwy" firstAttribute="height" secondItem="v8G-s8-aLx" secondAttribute="height" id="hu0-1r-Cad"/>
-                <constraint firstItem="MTF-oF-Bwy" firstAttribute="leading" secondItem="v8G-s8-aLx" secondAttribute="trailing" constant="8" id="k8g-xn-Jkq"/>
                 <constraint firstItem="v8G-s8-aLx" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="qdT-9A-AK0"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="MTF-oF-Bwy" secondAttribute="bottom" id="qy6-Xw-i4g"/>
-                <constraint firstItem="MTF-oF-Bwy" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="v4r-ca-hN8"/>
+                <constraint firstItem="MTF-oF-Bwy" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="t55-lY-kor"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOsView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOsView.swift
@@ -12,4 +12,12 @@ final class SBOsView: UIView {
     @IBOutlet weak var strikeView: SBOView!
     @IBOutlet weak var ballView: SBOView!
     @IBOutlet weak var outView: SBOView!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
 }

--- a/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOsView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/Play/SBOsView.swift
@@ -1,0 +1,15 @@
+//
+//  BoardCountsView.swift
+//  BaseballGame
+//
+//  Created by kimdo2297 on 2020/05/10.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class SBOsView: UIView {
+    @IBOutlet weak var strikeView: SBOView!
+    @IBOutlet weak var ballView: SBOView!
+    @IBOutlet weak var outView: SBOView!
+}

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.swift
@@ -10,6 +10,11 @@ import UIKit
 
 @IBDesignable
 final class ScoreView: UIView, WithXib {
+    @IBOutlet weak var awayTeamName: TitleLabel!
+    @IBOutlet weak var awayTeamScore: TitleLabel!
+    @IBOutlet weak var homeTeamName: TitleLabel!
+    @IBOutlet weak var homeTeamScore: TitleLabel!
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         insertXibView()

--- a/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.xib
+++ b/iOS/BaseballGame/BaseballGame/Views/Game/ScoreView.xib
@@ -7,7 +7,14 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ScoreView" customModule="BaseballGame" customModuleProvider="target">
+            <connections>
+                <outlet property="awayTeamName" destination="ROC-oc-Qsk" id="fQ7-Yi-c0s"/>
+                <outlet property="awayTeamScore" destination="Igj-WT-xhG" id="xG9-rU-aaL"/>
+                <outlet property="homeTeamName" destination="c17-Ac-Np9" id="Xgy-3x-Zu0"/>
+                <outlet property="homeTeamScore" destination="r03-xK-7nq" id="F6R-Pq-889"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>

--- a/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
+++ b/iOS/BaseballGame/BaseballGame/Views/GameRoom/PrevButton.swift
@@ -18,17 +18,17 @@ final class PrevButton: UIButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
         translatesAutoresizingMaskIntoConstraints = false
-        confugure()
+        configure()
         configureTarget()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        confugure()
+        configure()
         configureTarget()
     }
     
-    private func confugure() {
+    private func configure() {
         setImage(UIImage(systemName: "arrow.left"), for: .normal)
         tintColor = .systemRed
         imageView?.contentMode = .scaleAspectFit


### PR DESCRIPTION
이슈 #5 를 해결하였습니다.

* 스토리보드를 사용하였습니다. 
* S,B,O 의 Count를 보여주는 뷰를 SBOView.xib로 만들어서 재사용하였습니다. 
* 반복해서 사용해야 뷰들을 custom view로 만들어서 재사용하였습니다. (`PlayTableLabel`, `OrderLabel`)
* 1루,2루3루는 다음 이슈에서 그릴 예정입니다. 
* tableView와 customCell만 구현했고, dataSource, viewModel 객체등 실질적인 코드는 구현하지 않습니다. 이는 이후 네트워크 연동할때 구현할 예정입니다.

> 고민인 점 
* SBO의 StackView에 우선 4개의 뷰(Element)를 채우고 하나의 뷰만 보이게 하고 나머지 3개의 뷰들은 isHidden을 true를 주어 보았습니다. 근데 하나의 뷰(Element)만 스택뷰의 너비, 높이를 가득 채워 오토레이아웃 충돌 문제가 발생하였고, 
이를 해결하기 위해 isHidden 프로퍼티를 사용하지 않고, 나머지 3개의 뷰를 투명색으로 두어서 문제를 해결하였습니다. 근데 투명색을 사용하지 않고 isHidden 프로퍼티를 사용하고 싶은데, 방법을 모르겠습니다.. 😭

> 앱 실행화면 

<img width="224" alt="gameplay" src="https://user-images.githubusercontent.com/38216027/81497835-16ca6c00-92fc-11ea-8241-8b417979b348.png">
